### PR TITLE
Preflight de calidad para agentes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,9 @@ Invariantes y errores tipicos:
 
 - No asumas que `src/data/local/` existe, esta poblado o puede abrirse sin necesidad.
 - No mezcles un informe mensual y un `portfolio_metrics_snapshot` con fechas distintas; el pipeline debe bloquearlo.
+- Las interfaces y ejecuciones de usuario deben entrar por
+  `RunMonthlyAgentsUseCase`: el preflight bloquea errores antes de construir
+  providers y audita el intento cuando la persistencia esta activa.
 - No uses `.\scripts\run_demo.ps1` en automatizacion: abre Streamlit y queda vivo.
 - No llames desde Streamlit a `src.agents`, `src.reports`, `src.market_data` o importadores si ya hay caso de uso en `src/application/`.
 - No cambies prompts/agentes sin mantener la auditoria: plan, acciones, fuentes, prompts, warnings, inputs y outputs.
@@ -85,6 +88,7 @@ Mapa rapido de tests por area:
 | `src/application/` | `tests\test_application_layer.py`, `tests\test_interface_boundaries.py` |
 | Agentes | `tests\test_agent_*.py`, `tests\test_*agente*.py`, `tests\test_monitor_tematico.py`, `tests\test_analista_activos.py`, `tests\test_asistente_aportacion_mensual.py` |
 | Auditoria de agentes | `tests\test_agent_audit_trail.py`, `tests\test_application_layer.py` |
+| Preflight de agentes | `tests\test_data_quality.py`, `tests\test_application_layer.py`, `tests\test_agent_audit_trail.py`, `tests\test_run_monthly_agents_cli.py` |
 | Dashboard | `tests\test_dashboard_transforms.py`, `tests\test_streamlit_dashboard_uploads.py` |
 | DEGIRO/importacion | `tests\test_degiro_*.py` |
 | Portfolio/metricas | `tests\test_portfolio_metrics.py`, `tests\test_positions.py`, `tests\test_portfolio_state_projection.py`, `tests\test_portfolio_contributions.py` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ proyecto usa [versionado semántico](https://semver.org/lang/es/).
   externas para dashboard, informes y futuras interfaces.
 - Providers `synthetic` de precios y FX que mantienen la demo completamente
   offline, además de búsqueda `static` determinista para agentes.
+- Auditoría `preflight.json` para runs permitidos e intentos bloqueados.
 
 ### Cambiado
 
@@ -32,6 +33,8 @@ proyecto usa [versionado semántico](https://semver.org/lang/es/).
   `src/application/` en lugar de acceder directamente al dominio.
 - Los defaults de agentes son `llm_provider=static` y
   `search_provider=null`; `static/static` queda como modo demo offline completo.
+- La ejecución mensual aplica quality checks obligatorios antes de llamar a
+  providers; los warnings continúan como `partial`.
 
 ### Corregido
 
@@ -45,6 +48,8 @@ proyecto usa [versionado semántico](https://semver.org/lang/es/).
   valores no finitos en `null`.
 - La salida humana del runner temático conserva el estado del agente mientras
   `ApplicationResult` usa el vocabulario normalizado de la capa de aplicación.
+- CLI y Streamlit comparten el bloqueo estructurado por calidad y no crean
+  resultados ficticios cuando el preflight falla.
 
 ### Seguridad
 

--- a/docs/api_contracts.md
+++ b/docs/api_contracts.md
@@ -302,7 +302,8 @@ Ejecuta el pipeline mensual de agentes.
 Caso de uso base:
 
 - `RunMonthlyAgentsUseCase`
-- `RunAgentQualityChecksUseCase` como preflight recomendado
+- `RunAgentQualityChecksUseCase` como preflight obligatorio dentro del caso de
+  uso anterior
 - `BuildAgentDashboardSnapshotUseCase` si la UI envia snapshot preparado desde
   estado de cartera
 
@@ -335,19 +336,40 @@ Respuesta:
   "status": "succeeded",
   "message": "Monthly agents completed successfully.",
   "warnings": [],
+  "preflight": {
+    "status": "passed",
+    "can_run_agents": true,
+    "counts": {"error": 0, "warning": 0, "info": 1},
+    "issues": [
+      {
+        "code": "portfolio_metrics_ready",
+        "severity": "info",
+        "message": "Portfolio metrics passed agent input quality checks."
+      }
+    ]
+  },
   "artifacts": {
     "run_id": "20260623T101500123456",
     "as_of_date": "2026-06-23",
     "output_dir": "src/data/local/agents/monthly_pipeline/20260623T101500123456",
-    "monitor_tematico_status": "succeeded",
-    "analista_activos_status": "succeeded",
-    "asistente_aportacion_mensual_status": "succeeded"
+    "execution_status": "succeeded",
+    "preflight_status": "passed",
+    "monitor_tematico_status": "success",
+    "analista_activos_status": "success",
+    "asistente_aportacion_mensual_status": "success"
   }
 }
 ```
 
 Notas:
 
+- El ejemplo de `preflight` esta abreviado; el payload tipado tambien incluye
+  `schema_version`, `as_of_date`, `inputs` y `details`.
+- Si el preflight bloquea, la respuesta usa `status=failed`,
+  `artifacts.execution_status=blocked` y no incluye un resultado de pipeline.
+  Con `persist=true` puede guardar `preflight.json` y `run_metadata.json`, pero
+  nunca resultados ficticios de agentes.
+- Los warnings de calidad permiten ejecutar y fuerzan `status=partial`.
 - El contrato usa defaults offline seguros:
   `llm_provider=static` y `search_provider=null`. La demo publica puede optar
   por `static/static` para añadir contexto de busqueda sintetico.
@@ -387,9 +409,21 @@ Respuesta:
       "output_dir": "src/data/local/agents/monthly_pipeline/20260623T101500123456",
       "status": "succeeded",
       "agent_statuses": {
-        "monitor_tematico": "succeeded",
-        "analista_activos": "succeeded",
-        "asistente_aportacion_mensual": "succeeded"
+        "monitor_tematico": "success",
+        "analista_activos": "success",
+        "asistente_aportacion_mensual": "success"
+      }
+    },
+    {
+      "run_id": "20260624T101500123456",
+      "as_of_date": "2026-06-24",
+      "generated_at": "2026-06-24T10:15:00+02:00",
+      "output_dir": "src/data/local/agents/monthly_pipeline/20260624T101500123456",
+      "status": "blocked",
+      "agent_statuses": {
+        "monitor_tematico": "not_run",
+        "analista_activos": "not_run",
+        "asistente_aportacion_mensual": "not_run"
       }
     }
   ]
@@ -415,6 +449,14 @@ Respuesta:
     "llm_provider": "static",
     "search_provider": "null"
   },
+  "preflight": {
+    "schema_version": 1,
+    "status": "passed",
+    "can_run_agents": true,
+    "as_of_date": "2026-06-23",
+    "counts": {"error": 0, "warning": 0, "info": 1},
+    "issues": []
+  },
   "inputs": [
     {
       "key": "investment_brief",
@@ -424,17 +466,17 @@ Respuesta:
   ],
   "agents": {
     "monitor_tematico": {
-      "status": "succeeded",
+      "status": "success",
       "summary": "Resumen corto del agente.",
       "warnings": []
     },
     "analista_activos": {
-      "status": "succeeded",
+      "status": "success",
       "summary": "Resumen corto del agente.",
       "warnings": []
     },
     "asistente_aportacion_mensual": {
-      "status": "succeeded",
+      "status": "success",
       "summary": "Resumen corto del agente.",
       "warnings": []
     }
@@ -442,13 +484,16 @@ Respuesta:
   "artifact_paths": {
     "pipeline_result": "src/data/local/agents/monthly_pipeline/20260623T101500123456/pipeline_result.json",
     "run_metadata": "src/data/local/agents/monthly_pipeline/20260623T101500123456/run_metadata.json",
-    "input_payload": "src/data/local/agents/monthly_pipeline/20260623T101500123456/input_payload.json"
+    "input_payload": "src/data/local/agents/monthly_pipeline/20260623T101500123456/input_payload.json",
+    "preflight": "src/data/local/agents/monthly_pipeline/20260623T101500123456/preflight.json"
   }
 }
 ```
 
 Notas:
 
+- Un run `blocked` devuelve su `preflight`, metadata e inputs disponibles, pero
+  no tiene `pipeline_result` ni outputs de agentes.
 - El endpoint debe devolver resumen y metadatos, no necesariamente el JSON
   completo de auditoria si es muy grande.
 - Para ver bruto: posible endpoint futuro

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,7 +37,8 @@ Fronteras ya disponibles:
 - `InferFxRequirementsUseCase`, `RefreshFxUseCase` y
   `RefreshMarketDataUseCase` para market data;
 - `GenerateMonthlyReportUseCase` para informes;
-- `RunMonthlyAgentsUseCase` y `RunMonitorTematicoUseCase` para agentes;
+- `RunMonthlyAgentsUseCase`, con preflight bloqueante obligatorio, y
+  `RunMonitorTematicoUseCase` para agentes;
 - `ReadInvestmentBriefUseCase` y `UpdateInvestmentBriefUseCase` para leer y
   guardar el mandato local sin escribir desde la interfaz.
 

--- a/docs/monthly_pipeline.md
+++ b/docs/monthly_pipeline.md
@@ -32,6 +32,10 @@ Las interfaces comparten los mismos casos de uso:
 - agentes: `RunMonthlyAgentsUseCase` y, para ejecucion aislada,
   `RunMonitorTematicoUseCase`.
 
+`RunMonthlyAgentsUseCase` ejecuta un preflight determinista obligatorio. Errores
+de valoracion, precios, FX o fechas bloquean antes de llamar a LLM/busqueda. Los
+warnings quedan auditados y permiten continuar con estado `partial`.
+
 Para una actualizacion rapida sin importar nuevos CSVs ni generar informe, usa
 `Vista general` -> `Actualizar a hoy`. Ese boton refresca FX y precios hasta la
 fecha actual, limpia la cache y mantiene el ultimo snapshot DEGIRO como ancla.
@@ -50,6 +54,7 @@ necesariamente la fecha del snapshot.
 - Bodega DuckDB: `src/data/local/portfolio.duckdb`
 - Informes mensuales: `src/data/local/reports/`
 - Resultados de agentes: `src/data/local/agents/monthly_pipeline/<run_id>/pipeline_result.json`
+- Preflight de calidad: `src/data/local/agents/monthly_pipeline/<run_id>/preflight.json`
 - Audit trail de agentes: `src/data/local/agents/monthly_pipeline/<run_id>/run_metadata.json`,
   `input_payload.json` y `agents/<agent_name>/...`
 - Overrides temporales de informes para agentes: `src/data/local/agents/input_overrides/latest_monthly_report_override_YYYY-MM-DD.md`
@@ -78,10 +83,12 @@ necesariamente la fecha del snapshot.
   informe mensual y el `as_of_date` de `portfolio_metrics_snapshot` deben
   coincidir. Si se pasa un informe Markdown manual, la fecha se extrae de
   `as_of_date:` en el frontmatter o del titulo `Informe mensual ... YYYY-MM-DD`.
-- Desde Streamlit la validacion es mas estricta: el informe seleccionado y el
-  snapshot enviado a agentes deben coincidir tambien con la fecha valorada
-  actual de la cartera. Si no coinciden, hay que generar un informe nuevo antes
-  de ejecutar agentes.
+- Si el preflight bloquea, el comando termina con codigo `1` y, salvo que se use
+  `--no-persist`, guarda el intento sin crear resultados ni prompts de agentes.
+  Con solo warnings ejecuta la red y termina con codigo `0`.
+- Streamlit envia sus metricas y el snapshot editable al mismo
+  `RunMonthlyAgentsUseCase` que usa CLI, y muestra el preflight comun. Si las
+  fechas no coinciden, hay que generar un informe nuevo antes de ejecutar.
 - Antes de llamar a los agentes, `portfolio_metrics_snapshot` se enriquece con
   `asset_overrides.csv`: nombre normalizado, ticker, mercado y divisa de trading.
   Si DEGIRO entrega un nombre truncado, se conserva como `broker_asset_name` y

--- a/docs/streamlit_dashboard.md
+++ b/docs/streamlit_dashboard.md
@@ -93,12 +93,12 @@ oficiales de DEGIRO, primero debes subir/importar las exportaciones en
    ejecucion real usa `openai/tavily` si tienes `TAVILY_API_KEY`;
    `openai/duckduckgo` queda como fallback best-effort sin API key.
 
-La pestaña `Agentes` bloquea la ejecucion si el informe mensual seleccionado no
-corresponde a la fecha valorada actual de la cartera, o si el
-`portfolio_metrics_snapshot` editable tiene otro `as_of_date`. Esto evita mezclar
-un informe antiguo con metricas actuales. Si aparece el bloqueo, vuelve a
-`Actualizar datos` y genera un informe nuevo para la fecha actual antes de
-ejecutar la red.
+La pestaña `Agentes` envia los inputs a `RunMonthlyAgentsUseCase`, que ejecuta el
+mismo preflight usado por CLI. Si el informe, las metricas calculadas y el
+`portfolio_metrics_snapshot` no comparten fecha, o faltan precios/FX, la UI
+muestra los codigos de calidad y no se construyen providers. Si aparece el
+bloqueo, vuelve a `Actualizar datos` y corrige los datos o genera un informe
+nuevo antes de ejecutar la red.
 
 `BuildAgentDashboardSnapshotUseCase` prepara el
 `portfolio_metrics_snapshot` editable y aplica `asset_overrides.csv`. Cuando
@@ -112,7 +112,7 @@ La pestana `Agentes` incluye un bloque `Auditoria de agentes` para revisar runs
 persistidos en `src/data/local/agents/monthly_pipeline/<run_id>/` o en el
 directorio demo equivalente. Esta vista permite inspeccionar:
 
-- estado del run, fechas, inputs y versiones de prompts;
+- estado del run, preflight de calidad, fechas, inputs y versiones de prompts;
 - plan interno, acciones permitidas, acciones usadas, acciones descartadas y
   base de decision de cada agente;
 - warnings y errores;
@@ -125,6 +125,9 @@ directorio demo equivalente. Esta vista permite inspeccionar:
 La `raw_response` puede aparecer como `not_captured` porque los proveedores
 actuales devuelven objetos de dominio ya parseados. Si mas adelante interesa
 auditar la respuesta bruta del LLM, habra que ampliar el contrato de providers.
+Los intentos bloqueados persistidos tambien aparecen en la lista con estado
+`blocked`. Incluyen metadata, inputs y preflight, pero no `pipeline_result.json`,
+outputs ni tabs de agentes vacios.
 
 Al guardar desde la UI, el dashboard detecta el tipo de exportacion por el
 nombre del archivo y lo copia a `incoming` con el nombre canonico que exige el

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -57,6 +57,11 @@ Ejemplo de pipeline mensual local:
 .\.venv\Scripts\python.exe scripts\run_monthly_agents.py --llm-provider static --search-provider null
 ```
 
+Cuando los inputs pueden prepararse, el runner imprime el preflight de calidad.
+Devuelve codigo `1` y no llama a providers si detecta errores bloqueantes; los
+warnings permiten continuar y mantienen codigo `0`. `--no-persist` desactiva
+tanto el resultado del pipeline como su audit trail.
+
 `static/null` es el baseline offline: el monitor no recibe resultados de
 busqueda. Para una demo offline mas completa usa `static/static`; la busqueda
 devuelve exclusivamente fixtures sinteticos:

--- a/scripts/run_monthly_agents.py
+++ b/scripts/run_monthly_agents.py
@@ -22,7 +22,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--user-satellite-interest", help="Optional one-off satellite idea for this run.")
     parser.add_argument("--llm-provider", choices=("static", "openai"), default="static")
     parser.add_argument("--search-provider", choices=("null", "static", "duckduckgo", "tavily"), default="null")
-    parser.add_argument("--no-persist", action="store_true", help="Do not write pipeline_result.json.")
+    parser.add_argument("--no-persist", action="store_true", help="Do not write pipeline or audit artifacts.")
     parser.add_argument("--output-dir", type=Path, help="Output directory for persisted agent results.")
     return parser.parse_args()
 
@@ -30,19 +30,39 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     args = parse_args()
     settings = get_settings()
-    use_case_result = RunMonthlyAgentsUseCase(settings=settings).execute(
-        RunMonthlyAgentsRequest(
-            investment_brief_text=args.investment_brief_text,
-            investment_brief_path=args.investment_brief_file,
-            monthly_report_path=args.monthly_report,
-            user_satellite_interest=args.user_satellite_interest,
-            llm_provider=args.llm_provider,
-            search_provider=args.search_provider,
-            persist=not args.no_persist,
-            output_dir=args.output_dir,
+    try:
+        use_case_result = RunMonthlyAgentsUseCase(settings=settings).execute(
+            RunMonthlyAgentsRequest(
+                investment_brief_text=args.investment_brief_text,
+                investment_brief_path=args.investment_brief_file,
+                monthly_report_path=args.monthly_report,
+                user_satellite_interest=args.user_satellite_interest,
+                llm_provider=args.llm_provider,
+                search_provider=args.search_provider,
+                persist=not args.no_persist,
+                output_dir=args.output_dir,
+            )
         )
+    except (FileNotFoundError, OSError, ValueError) as exc:
+        print(f"Input error: {exc}")
+        return 1
+    preflight = use_case_result.quality_result.to_dict()
+    counts = preflight["counts"]
+    print(
+        "Preflight: "
+        f"{preflight['status']} | errors={counts['error']} "
+        f"| warnings={counts['warning']} | as_of={preflight['as_of_date'] or '-'}"
     )
+    for issue in preflight["issues"]:
+        print(f"  {issue['severity']}: {issue['code']} | {issue['message']}")
+
     result = use_case_result.pipeline_result
+    if result is None:
+        print(use_case_result.result.message)
+        output_dir = use_case_result.result.artifacts.get("output_dir")
+        if output_dir:
+            print(f"Audit: {output_dir}")
+        return 1
 
     print(f"Run: {result.run_id}")
     print(f"As of: {result.as_of_date.isoformat()}")
@@ -56,7 +76,7 @@ def main() -> int:
         print(f"- {name}: {agent_result.status} | findings={len(agent_result.findings)} | {agent_result.summary}")
         for warning in agent_result.warnings:
             print(f"  warning: {warning}")
-    return 0
+    return 1 if use_case_result.result.failed else 0
 
 
 if __name__ == "__main__":

--- a/src/agents/README.md
+++ b/src/agents/README.md
@@ -176,16 +176,17 @@ snapshot `2026-05-26` se rechaza antes de llamar a los agentes.
 
 ## Quality checks previos
 
-La capa `src.portfolio.data_quality` define checks deterministas que pueden
-ejecutarse antes de los agentes mediante
-`RunAgentQualityChecksUseCase` en `src.application.quality_checks`.
+La capa `src.portfolio.data_quality` define checks deterministas que
+`RunMonthlyAgentsUseCase` ejecuta obligatoriamente mediante
+`RunAgentQualityChecksUseCase` antes de invocar el pipeline.
 
 El caso de uso devuelve `can_run_agents=False` y estado `failed` cuando faltan
 metricas, posiciones valoradas, precios, FX o cuando las fechas de informe,
 metricas calculadas y `portfolio_metrics_snapshot` no coinciden. La cobertura de
-rentabilidad incompleta se trata como warning. Independientemente de este
-preflight opcional, el pipeline rechaza siempre la mezcla de fechas descrita en
-la seccion anterior.
+rentabilidad incompleta se trata como warning y permite ejecutar con estado
+`partial`. Con `persist=True`, los bloqueos se auditan en `preflight.json` sin
+crear resultados ficticios de agentes. El pipeline mantiene ademas su
+validacion de fechas como segunda barrera interna.
 
 ## Identidad de activos
 
@@ -217,6 +218,7 @@ en `src/data/local/agents/monthly_pipeline/<run_id>/`. Ademas de
 `pipeline_result.json`, se guardan:
 
 - `run_metadata.json`: fecha, moneda base, estados por agente y versiones de prompts.
+- `preflight.json`: resultado, codigos, severidades y conteos de calidad.
 - `input_payload.json`: referencias de entrada completas usadas en el run.
 - `agents/<agent_name>/context.json`: contexto efectivo del agente.
 - `agents/<agent_name>/request.json`: request estructurada enviada al agente.
@@ -228,6 +230,9 @@ en `src/data/local/agents/monthly_pipeline/<run_id>/`. Ademas de
 
 Estos artefactos viven bajo `src/data/local/`, por tanto son privados y estan
 ignorados por Git. Para demos publicas deben usarse datos sinteticos.
+Con persistencia activa, un intento bloqueado contiene `run_metadata.json`,
+`preflight.json` e `input_payload.json`, pero no `pipeline_result.json` ni
+carpetas de agentes.
 
 ## Prompts versionados
 

--- a/src/application/README.md
+++ b/src/application/README.md
@@ -42,7 +42,8 @@ adapta el script o la vista de Streamlit correspondiente.
 `RunAgentQualityChecksUseCase` centraliza las validaciones deterministas antes
 de ejecutar agentes: cobertura de valoracion, precios/FX faltantes, existencia
 de posiciones valoradas y alineacion de fechas entre metricas, informe mensual y
-`portfolio_metrics_snapshot`.
+`portfolio_metrics_snapshot`. Devuelve `failed` con errores bloqueantes,
+`partial` cuando solo hay warnings y `succeeded` cuando el preflight esta limpio.
 
 ## Agentes mensuales
 
@@ -50,6 +51,10 @@ de posiciones valoradas y alineacion de fechas entre metricas, informe mensual y
 y devuelve un `ApplicationResult` con estado agregado, warnings y artefactos
 principales (`run_id`, `as_of_date`, `output_dir`). Scripts, Streamlit y futuras
 interfaces deben usar este caso de uso en vez de llamar directamente al pipeline.
+El caso de uso ejecuta siempre el preflight antes de construir providers. Un
+bloqueo devuelve `pipeline_result=None` y, con `persist=True`, guarda
+`preflight.json` junto con `run_metadata.json`; un warning permite continuar y
+fuerza estado agregado `partial`.
 
 `ListAgentRunsUseCase` y `GetAgentRunAuditUseCase` exponen read models de la
 auditoria persistida en disco. Streamlit los usa para visualizar plan interno,

--- a/src/application/agent_audit.py
+++ b/src/application/agent_audit.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import json
 from pathlib import Path
 from typing import Any
@@ -40,6 +40,7 @@ class GetAgentRunAuditResult:
     run_metadata: dict[str, Any]
     input_payload: dict[str, Any]
     agents: dict[str, dict[str, Any]]
+    preflight: dict[str, Any] = field(default_factory=dict)
 
 
 class ListAgentRunsUseCase:
@@ -81,6 +82,7 @@ class GetAgentRunAuditUseCase:
 
         run_metadata = _read_json_or_empty(output_dir / "run_metadata.json")
         input_payload = _read_json_or_empty(output_dir / "input_payload.json")
+        preflight = _read_json_or_empty(output_dir / "preflight.json")
         agents = {
             agent_name: _read_agent_audit(output_dir / "agents" / agent_name)
             for agent_name in AGENT_NAMES
@@ -90,8 +92,77 @@ class GetAgentRunAuditUseCase:
             output_dir=output_dir,
             run_metadata=run_metadata,
             input_payload=input_payload,
+            preflight=preflight,
             agents=agents,
         )
+
+
+def persist_agent_preflight_audit(
+    *,
+    settings: Settings,
+    run_id: str,
+    as_of_date: str | None,
+    generated_at: str,
+    execution_status: str,
+    preflight: dict[str, Any],
+    output_dir: Path | None = None,
+    attach_to_existing_run: bool = False,
+) -> tuple[Path, Path]:
+    """Attach a quality preflight to a run or persist a blocked attempt."""
+    requested_dir = (
+        output_dir.expanduser().resolve()
+        if output_dir is not None
+        else settings.data_dir / "agents" / "monthly_pipeline" / run_id
+    )
+    if (
+        output_dir is not None
+        and not attach_to_existing_run
+        and requested_dir.exists()
+        and any(requested_dir.iterdir())
+    ):
+        # Preserve an existing audit directory instead of mixing two attempts.
+        base_dir = requested_dir / run_id
+    else:
+        base_dir = requested_dir
+    base_dir.mkdir(parents=True, exist_ok=True)
+    preflight_path = base_dir / "preflight.json"
+    _write_json(preflight_path, preflight)
+
+    metadata_path = base_dir / "run_metadata.json"
+    metadata = _read_json_or_empty(metadata_path)
+    if not metadata:
+        metadata = {
+            "run_id": run_id,
+            "as_of_date": as_of_date,
+            "generated_at": generated_at,
+            "base_currency": settings.default_currency,
+            "output_dir": str(base_dir),
+            "pipeline_result_path": None,
+            "agents": {name: {"status": "not_run"} for name in AGENT_NAMES},
+            "prompt_versions": {},
+        }
+    metadata["execution_status"] = execution_status
+    metadata["preflight"] = {
+        "status": preflight.get("status"),
+        "can_run_agents": preflight.get("can_run_agents"),
+        "error_count": (preflight.get("counts") or {}).get("error", 0),
+        "warning_count": (preflight.get("counts") or {}).get("warning", 0),
+        "path": preflight_path.name,
+    }
+    _write_json(metadata_path, metadata)
+
+    input_payload_path = base_dir / "input_payload.json"
+    if not input_payload_path.exists():
+        _write_json(
+            input_payload_path,
+            {
+                "run_id": run_id,
+                "as_of_date": as_of_date,
+                "inputs": [],
+                "preflight_inputs": preflight.get("inputs") or {},
+            },
+        )
+    return base_dir, preflight_path
 
 
 def _safe_run_id(value: str) -> str:
@@ -117,7 +188,10 @@ def _summary_from_metadata(metadata: dict[str, Any], *, run_dir: Path) -> AgentR
         name: str((metadata.get("agents") or {}).get(name, {}).get("status") or "unknown")
         for name in AGENT_NAMES
     }
-    if any(status == "failed" for status in agent_statuses.values()):
+    execution_status = str(metadata.get("execution_status") or "")
+    if execution_status in {"succeeded", "partial", "failed", "blocked"}:
+        status = execution_status
+    elif any(status == "failed" for status in agent_statuses.values()):
         status = "failed"
     elif any(status in {"partial", "unknown"} for status in agent_statuses.values()):
         status = "partial"
@@ -165,6 +239,12 @@ def _read_text_or_empty(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    temp_path = path.with_name(f".{path.name}.tmp")
+    temp_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    temp_path.replace(path)
+
+
 __all__ = [
     "AgentRunSummary",
     "GetAgentRunAuditRequest",
@@ -172,4 +252,5 @@ __all__ = [
     "GetAgentRunAuditUseCase",
     "ListAgentRunsResult",
     "ListAgentRunsUseCase",
+    "persist_agent_preflight_audit",
 ]

--- a/src/application/agents.py
+++ b/src/application/agents.py
@@ -3,13 +3,22 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import date, datetime
 from pathlib import Path
 from typing import Any, Mapping
 
 from src.agents import MonthlyAgentPipelineResult, run_monthly_agent_pipeline
+from src.agents.pipeline import extract_monthly_report_as_of_date
+from src.application.agent_audit import persist_agent_preflight_audit
+from src.application.quality_checks import (
+    RunAgentQualityChecksRequest,
+    RunAgentQualityChecksResult,
+    RunAgentQualityChecksUseCase,
+)
 from src.application.types import ApplicationResult
 from src.config import Settings, get_settings
-from src.portfolio import PortfolioMetricsResult
+from src.portfolio import PortfolioMetricsResult, calculate_portfolio_metrics_from_normalized_degiro
+from src.reports import get_latest_monthly_report
 
 
 @dataclass(frozen=True)
@@ -31,7 +40,8 @@ class RunMonthlyAgentsRequest:
 @dataclass(frozen=True)
 class RunMonthlyAgentsResult:
     result: ApplicationResult
-    pipeline_result: MonthlyAgentPipelineResult
+    quality_result: RunAgentQualityChecksResult
+    pipeline_result: MonthlyAgentPipelineResult | None
 
 
 class RunMonthlyAgentsUseCase:
@@ -44,12 +54,36 @@ class RunMonthlyAgentsUseCase:
 
     def execute(self, request: RunMonthlyAgentsRequest | None = None) -> RunMonthlyAgentsResult:
         resolved_request = request or RunMonthlyAgentsRequest()
+        resolved_metrics = resolved_request.metrics or calculate_portfolio_metrics_from_normalized_degiro(
+            settings=self.settings,
+            persist=False,
+        )
+        resolved_report_path, monthly_report_date = _resolve_monthly_report_for_preflight(
+            settings=self.settings,
+            requested_path=resolved_request.monthly_report_path,
+        )
+        quality_result = RunAgentQualityChecksUseCase(settings=self.settings).execute(
+            RunAgentQualityChecksRequest(
+                metrics=resolved_metrics,
+                monthly_report_date=monthly_report_date,
+                require_monthly_report_date=resolved_report_path is not None,
+                portfolio_metrics_snapshot=resolved_request.portfolio_metrics_snapshot,
+            )
+        )
+        preflight_payload = quality_result.to_dict()
+        if not quality_result.can_run_agents:
+            return self._blocked_result(
+                request=resolved_request,
+                quality_result=quality_result,
+                preflight_payload=preflight_payload,
+            )
+
         pipeline_result = run_monthly_agent_pipeline(
             settings=self.settings,
             investment_brief_text=resolved_request.investment_brief_text,
             investment_brief_path=resolved_request.investment_brief_path,
-            monthly_report_path=resolved_request.monthly_report_path,
-            metrics=resolved_request.metrics,
+            monthly_report_path=resolved_report_path,
+            metrics=resolved_metrics,
             user_satellite_interest=resolved_request.user_satellite_interest,
             llm_provider=resolved_request.llm_provider,
             search_provider=resolved_request.search_provider,
@@ -69,29 +103,105 @@ class RunMonthlyAgentsUseCase:
         if failed_agents:
             status = "failed"
             message = f"Monthly agents finished with failed agent(s): {', '.join(failed_agents)}."
-        elif partial_agents:
+        elif partial_agents or quality_result.result.status == "partial":
             status = "partial"
-            message = f"Monthly agents finished with partial agent(s): {', '.join(partial_agents)}."
+            if partial_agents:
+                message = f"Monthly agents finished with partial agent(s): {', '.join(partial_agents)}."
+            else:
+                message = "Monthly agents completed with quality preflight warning(s)."
         else:
             status = "succeeded"
             message = "Monthly agents completed successfully."
+
+        preflight_path = None
+        if resolved_request.persist and pipeline_result.output_dir is not None:
+            _, preflight_path = persist_agent_preflight_audit(
+                settings=self.settings,
+                run_id=pipeline_result.run_id,
+                as_of_date=pipeline_result.as_of_date.isoformat(),
+                generated_at=datetime.now().astimezone().isoformat(),
+                execution_status=status,
+                preflight=preflight_payload,
+                output_dir=pipeline_result.output_dir,
+                attach_to_existing_run=True,
+            )
 
         return RunMonthlyAgentsResult(
             result=ApplicationResult(
                 name=self.name,
                 status=status,
                 message=message,
-                warnings=_collect_warnings(pipeline_result),
+                warnings=(*_quality_warnings(quality_result), *_collect_warnings(pipeline_result)),
                 artifacts={
                     "run_id": pipeline_result.run_id,
                     "as_of_date": pipeline_result.as_of_date.isoformat(),
                     "output_dir": pipeline_result.output_dir,
+                    "execution_status": status,
+                    "preflight_status": preflight_payload["status"],
+                    "preflight_error_count": quality_result.report.error_count,
+                    "preflight_warning_count": quality_result.report.warning_count,
+                    "preflight_path": preflight_path,
                     "monitor_tematico_status": pipeline_result.monitor_tematico.status,
                     "analista_activos_status": pipeline_result.analista_activos.status,
                     "asistente_aportacion_mensual_status": pipeline_result.asistente_aportacion_mensual.status,
                 },
             ),
+            quality_result=quality_result,
             pipeline_result=pipeline_result,
+        )
+
+    def _blocked_result(
+        self,
+        *,
+        request: RunMonthlyAgentsRequest,
+        quality_result: RunAgentQualityChecksResult,
+        preflight_payload: dict[str, Any],
+    ) -> RunMonthlyAgentsResult:
+        generated_at = datetime.now().astimezone()
+        run_id = generated_at.strftime("%Y%m%dT%H%M%S%f")
+        output_dir = None
+        preflight_path = None
+        if request.persist:
+            output_dir, preflight_path = persist_agent_preflight_audit(
+                settings=self.settings,
+                run_id=run_id,
+                as_of_date=(
+                    quality_result.report.as_of_date.isoformat()
+                    if quality_result.report.as_of_date
+                    else None
+                ),
+                generated_at=generated_at.isoformat(),
+                execution_status="blocked",
+                preflight=preflight_payload,
+                output_dir=request.output_dir,
+            )
+        blocking_codes = ", ".join(
+            issue.code for issue in quality_result.report.issues if issue.blocks_agents
+        )
+        return RunMonthlyAgentsResult(
+            result=ApplicationResult(
+                name=self.name,
+                status="failed",
+                message=f"Monthly agents blocked by quality preflight: {blocking_codes}.",
+                warnings=_quality_warnings(quality_result),
+                artifacts={
+                    "run_id": run_id,
+                    "as_of_date": (
+                        quality_result.report.as_of_date.isoformat()
+                        if quality_result.report.as_of_date
+                        else None
+                    ),
+                    "output_dir": output_dir,
+                    "execution_status": "blocked",
+                    "preflight_status": preflight_payload["status"],
+                    "preflight_error_count": quality_result.report.error_count,
+                    "preflight_warning_count": quality_result.report.warning_count,
+                    "preflight_path": preflight_path,
+                    "blocking_issue_codes": blocking_codes,
+                },
+            ),
+            quality_result=quality_result,
+            pipeline_result=None,
         )
 
 
@@ -104,6 +214,32 @@ def _collect_warnings(result: MonthlyAgentPipelineResult) -> tuple[str, ...]:
     ):
         warnings.extend(f"{agent_name}: {warning}" for warning in agent_result.warnings)
     return tuple(warnings)
+
+
+def _quality_warnings(result: RunAgentQualityChecksResult) -> tuple[str, ...]:
+    return tuple(
+        f"quality_preflight: {issue.message}"
+        for issue in result.report.issues
+        if issue.severity == "warning"
+    )
+
+
+def _resolve_monthly_report_for_preflight(
+    *,
+    settings: Settings,
+    requested_path: Path | None,
+) -> tuple[Path | None, date | None]:
+    if requested_path is not None:
+        path = requested_path.expanduser().resolve()
+        content = path.read_text(encoding="utf-8")
+        return path, extract_monthly_report_as_of_date(content, path=path)
+
+    latest = get_latest_monthly_report(settings=settings)
+    if latest is None:
+        return None, None
+    path = Path(latest.report_path).expanduser().resolve()
+    content = path.read_text(encoding="utf-8")
+    return path, extract_monthly_report_as_of_date(content, path=path)
 
 
 __all__ = [

--- a/src/application/quality_checks.py
+++ b/src/application/quality_checks.py
@@ -2,20 +2,25 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date
 from typing import Any, Mapping
 
 from src.application.types import ApplicationResult
 from src.config import Settings, get_settings
 from src.portfolio import PortfolioMetricsResult, calculate_portfolio_metrics_from_normalized_degiro
-from src.portfolio.data_quality import DataQualityReport, check_agent_input_quality
+from src.portfolio.data_quality import (
+    DataQualityReport,
+    check_agent_input_quality,
+    extract_snapshot_as_of_date,
+)
 
 
 @dataclass(frozen=True)
 class RunAgentQualityChecksRequest:
     metrics: PortfolioMetricsResult | None = None
     monthly_report_date: date | None = None
+    require_monthly_report_date: bool = False
     portfolio_metrics_snapshot: Mapping[str, Any] | None = None
     min_valuation_coverage_ratio: float = 1.0
     min_return_coverage_ratio: float = 0.8
@@ -25,10 +30,52 @@ class RunAgentQualityChecksRequest:
 class RunAgentQualityChecksResult:
     result: ApplicationResult
     report: DataQualityReport
+    request: RunAgentQualityChecksRequest = field(default_factory=RunAgentQualityChecksRequest)
 
     @property
     def can_run_agents(self) -> bool:
         return self.report.can_run_agents
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the stable preflight payload used by UI and audit trails."""
+        snapshot_date = extract_snapshot_as_of_date(self.request.portfolio_metrics_snapshot)
+        if not self.report.can_run_agents:
+            status = "blocked"
+        elif self.report.warning_count:
+            status = "passed_with_warnings"
+        else:
+            status = "passed"
+        return {
+            "schema_version": 1,
+            "status": status,
+            "can_run_agents": self.report.can_run_agents,
+            "as_of_date": self.report.as_of_date.isoformat() if self.report.as_of_date else None,
+            "counts": {
+                "error": self.report.error_count,
+                "warning": self.report.warning_count,
+                "info": self.report.info_count,
+            },
+            "issues": [
+                {
+                    "code": issue.code,
+                    "severity": issue.severity,
+                    "message": issue.message,
+                    "details": dict(issue.details or {}),
+                }
+                for issue in self.report.issues
+            ],
+            "inputs": {
+                "monthly_report_date": (
+                    self.request.monthly_report_date.isoformat()
+                    if self.request.monthly_report_date
+                    else None
+                ),
+                "require_monthly_report_date": self.request.require_monthly_report_date,
+                "snapshot_as_of_date": snapshot_date.isoformat() if snapshot_date else None,
+                "min_valuation_coverage_ratio": self.request.min_valuation_coverage_ratio,
+                "min_return_coverage_ratio": self.request.min_return_coverage_ratio,
+            },
+        }
 
 
 class RunAgentQualityChecksUseCase:
@@ -48,16 +95,20 @@ class RunAgentQualityChecksUseCase:
         report = check_agent_input_quality(
             metrics=metrics,
             monthly_report_date=resolved_request.monthly_report_date,
+            require_monthly_report_date=resolved_request.require_monthly_report_date,
             portfolio_metrics_snapshot=resolved_request.portfolio_metrics_snapshot,
             min_valuation_coverage_ratio=resolved_request.min_valuation_coverage_ratio,
             min_return_coverage_ratio=resolved_request.min_return_coverage_ratio,
         )
-        status = "succeeded" if report.can_run_agents else "failed"
-        message = (
-            "Agent input quality checks passed."
-            if report.can_run_agents
-            else f"Agent input quality checks failed with {report.error_count} blocking issue(s)."
-        )
+        if not report.can_run_agents:
+            status = "failed"
+            message = f"Agent input quality checks failed with {report.error_count} blocking issue(s)."
+        elif report.warning_count:
+            status = "partial"
+            message = f"Agent input quality checks passed with {report.warning_count} warning(s)."
+        else:
+            status = "succeeded"
+            message = "Agent input quality checks passed."
         return RunAgentQualityChecksResult(
             result=ApplicationResult(
                 name=self.name,
@@ -73,6 +124,7 @@ class RunAgentQualityChecksUseCase:
                 },
             ),
             report=report,
+            request=resolved_request,
         )
 
 

--- a/src/portfolio/dashboard_agents.py
+++ b/src/portfolio/dashboard_agents.py
@@ -156,7 +156,7 @@ def render_agents_tab(settings: Settings) -> None:
             report_option=report_option,
             report_text_input=report_text_input,
             snapshot_text_input=snapshot_text_input,
-            metrics_end_date=metrics.end_date,
+            metrics=metrics,
             target_weights_invalid=target_weights_invalid,
             send_target_weights=send_target_weights,
             target_weights=target_weights,
@@ -230,7 +230,10 @@ def _render_persisted_agent_audit(settings: Settings) -> None:
         st.error(str(exc))
         return
 
-    _render_run_overview(audit.run_metadata, audit.input_payload, audit.output_dir)
+    _render_run_overview(audit.run_metadata, audit.input_payload, audit.preflight, audit.output_dir)
+    if audit.run_metadata.get("execution_status") == "blocked":
+        st.info("Los agentes no se ejecutaron porque el preflight detecto errores bloqueantes.")
+        return
     agent_tabs = st.tabs(["monitor_tematico", "analista_activos", "asistente_aportacion_mensual"])
     for tab, agent_name in zip(
         agent_tabs,
@@ -241,7 +244,12 @@ def _render_persisted_agent_audit(settings: Settings) -> None:
             _render_agent_audit(agent_name, audit.agents.get(agent_name, {}))
 
 
-def _render_run_overview(run_metadata: Mapping[str, Any], input_payload: Mapping[str, Any], output_dir: Path) -> None:
+def _render_run_overview(
+    run_metadata: Mapping[str, Any],
+    input_payload: Mapping[str, Any],
+    preflight: Mapping[str, Any],
+    output_dir: Path,
+) -> None:
     st.markdown("#### Run")
     columns = st.columns(4)
     columns[0].metric("run_id", str(run_metadata.get("run_id") or output_dir.name))
@@ -256,6 +264,7 @@ def _render_run_overview(run_metadata: Mapping[str, Any], input_payload: Mapping
     if agent_statuses:
         st.dataframe(pd.DataFrame(agent_statuses), width="stretch", hide_index=True)
 
+    _render_quality_preflight(preflight)
     with st.expander("Inputs del run", expanded=False):
         _render_input_refs(input_payload.get("inputs") or [], key_prefix="run")
     with st.expander("Prompt versions", expanded=False):
@@ -419,7 +428,7 @@ def _run_agents_from_ui(
     report_option,
     report_text_input: str,
     snapshot_text_input: str,
-    metrics_end_date: date,
+    metrics,
     target_weights_invalid: bool,
     send_target_weights: bool,
     target_weights: dict[str, Any],
@@ -439,31 +448,15 @@ def _run_agents_from_ui(
     except Exception:
         st.error("`portfolio_metrics_snapshot` no es JSON valido.")
         return
-    snapshot_as_of = _snapshot_as_of_date(portfolio_metrics_snapshot)
     selected_report_date = extract_monthly_report_as_of_date(report_text_input, path=Path(report_option["path"]))
-    if selected_report_date is None:
-        st.error("El informe seleccionado no contiene una fecha `as_of_date` detectable.")
-        return
-    if selected_report_date != metrics_end_date:
-        st.error(
-            "Bloqueado: el informe mensual no corresponde a la cartera actual. "
-            f"Informe: {selected_report_date.isoformat()} | cartera: {metrics_end_date.isoformat()}."
-        )
-        return
-    if snapshot_as_of != metrics_end_date:
-        st.error(
-            "`portfolio_metrics_snapshot` no corresponde a la cartera actual. "
-            f"Snapshot: {snapshot_as_of.isoformat() if snapshot_as_of else 'sin fecha'} | "
-            f"cartera: {metrics_end_date.isoformat()}."
-        )
-        return
     if target_weights_invalid:
         st.error("`target_weights` esta activado pero no es un JSON valido.")
         return
 
     override_dir = settings.data_dir / "agents" / "input_overrides"
     override_dir.mkdir(parents=True, exist_ok=True)
-    report_override_path = override_dir / f"latest_monthly_report_override_{selected_report_date.isoformat()}.md"
+    report_date_label = selected_report_date.isoformat() if selected_report_date else "undated"
+    report_override_path = override_dir / f"latest_monthly_report_override_{report_date_label}.md"
     report_override_path.write_text(report_text_input, encoding="utf-8")
 
     request_parameters: dict[str, Any] = {}
@@ -475,6 +468,7 @@ def _run_agents_from_ui(
                 RunMonthlyAgentsRequest(
                     investment_brief_text=investment_brief,
                     monthly_report_path=report_override_path,
+                    metrics=metrics,
                     user_satellite_interest=user_interest or None,
                     monthly_budget=monthly_budget,
                     llm_provider=llm_provider,
@@ -484,11 +478,23 @@ def _run_agents_from_ui(
                     portfolio_metrics_snapshot=portfolio_metrics_snapshot,
                 )
             )
-            result = agents_result.pipeline_result
-    except ValueError as exc:
+    except (FileNotFoundError, OSError, ValueError) as exc:
         st.error(str(exc))
         return
-    st.success(f"Run {result.run_id} guardado en {result.output_dir}")
+    _render_quality_preflight(agents_result.quality_result.to_dict())
+    result = agents_result.pipeline_result
+    if result is None:
+        st.error(agents_result.result.message)
+        output_dir = agents_result.result.artifacts.get("output_dir")
+        if output_dir:
+            st.caption(f"Intento auditado en: {output_dir}")
+        return
+    if agents_result.result.status == "failed":
+        st.error(agents_result.result.message)
+    elif agents_result.result.status == "partial":
+        st.warning(agents_result.result.message)
+    else:
+        st.success(f"Run {result.run_id} guardado en {result.output_dir}")
     render_agent_result("monitor_tematico", result.monitor_tematico)
     render_agent_result("analista_activos", result.analista_activos)
     render_agent_result("asistente_aportacion_mensual", result.asistente_aportacion_mensual)
@@ -542,13 +548,19 @@ def _render_agent_inputs_summary(*, send_target_weights: bool, target_weights: M
             st.json(target_weights if target_weights else {"_status": "no definido"})
 
 
-def _snapshot_as_of_date(portfolio_metrics_snapshot: Mapping[str, Any]) -> date | None:
-    snapshot_as_of_raw = portfolio_metrics_snapshot.get("as_of_date")
-    try:
-        return date.fromisoformat(str(snapshot_as_of_raw)[:10]) if snapshot_as_of_raw else None
-    except ValueError:
-        st.error("`portfolio_metrics_snapshot.as_of_date` no es una fecha valida.")
-        return None
+def _render_quality_preflight(preflight: Mapping[str, Any]) -> None:
+    if not preflight:
+        return
+    st.markdown("#### Preflight de calidad")
+    counts = preflight.get("counts") or {}
+    columns = st.columns(4)
+    columns[0].metric("estado", str(preflight.get("status") or "-"))
+    columns[1].metric("errores", str(counts.get("error", 0)))
+    columns[2].metric("warnings", str(counts.get("warning", 0)))
+    columns[3].metric("fecha", str(preflight.get("as_of_date") or "-"))
+    issues = preflight.get("issues") or []
+    if issues:
+        st.dataframe(pd.DataFrame(issues), width="stretch", hide_index=True)
 
 
 def _markdown_list(values: Any) -> str:

--- a/src/portfolio/data_quality.py
+++ b/src/portfolio/data_quality.py
@@ -198,6 +198,7 @@ def check_agent_input_quality(
     *,
     metrics: PortfolioMetricsResult,
     monthly_report_date: date | None = None,
+    require_monthly_report_date: bool = False,
     portfolio_metrics_snapshot: Mapping[str, Any] | None = None,
     min_valuation_coverage_ratio: float = 1.0,
     min_return_coverage_ratio: float = 0.8,
@@ -212,12 +213,23 @@ def check_agent_input_quality(
     as_of_date = metrics_report.as_of_date
     snapshot_date = extract_snapshot_as_of_date(portfolio_metrics_snapshot)
 
+    if require_monthly_report_date and monthly_report_date is None:
+        issues.append(
+            DataQualityIssue(
+                code="monthly_report_date_missing",
+                severity="error",
+                message="The selected monthly report does not contain a valid as_of_date.",
+            )
+        )
     if portfolio_metrics_snapshot is not None and snapshot_date is None:
         issues.append(
             DataQualityIssue(
                 code="snapshot_date_missing",
                 severity="error",
-                message="portfolio_metrics_snapshot must include `as_of_date` or `daily.valuation_date`.",
+                message=(
+                    "portfolio_metrics_snapshot must include a valid "
+                    "`as_of_date` or `daily.valuation_date`."
+                ),
             )
         )
     if snapshot_date is not None and as_of_date is not None and snapshot_date != as_of_date:
@@ -277,7 +289,10 @@ def extract_snapshot_as_of_date(snapshot: Mapping[str, Any] | None) -> date | No
     if isinstance(raw_date, date):
         return raw_date
     if isinstance(raw_date, str) and raw_date.strip():
-        return date.fromisoformat(raw_date[:10])
+        try:
+            return date.fromisoformat(raw_date[:10])
+        except ValueError:
+            return None
     return None
 
 

--- a/tests/test_agent_audit_trail.py
+++ b/tests/test_agent_audit_trail.py
@@ -8,6 +8,12 @@ from uuid import uuid4
 
 from src.agents.models import AgentFinding, AgentInputRef, AgentResult
 from src.agents.pipeline import MonthlyAgentPipelineResult, _persist_pipeline_result
+from src.application.agent_audit import (
+    GetAgentRunAuditRequest,
+    GetAgentRunAuditUseCase,
+    ListAgentRunsUseCase,
+    persist_agent_preflight_audit,
+)
 from src.config import default_repo_root, load_settings
 
 
@@ -35,13 +41,26 @@ def test_persist_pipeline_result_writes_audit_trail_files() -> None:
         )
 
         persisted_dir = _persist_pipeline_result(result, settings=settings, output_dir=output_dir)
+        _, preflight_path = persist_agent_preflight_audit(
+            settings=settings,
+            run_id=result.run_id,
+            as_of_date=result.as_of_date.isoformat(),
+            generated_at="2026-05-26T10:00:00+02:00",
+            execution_status="succeeded",
+            preflight=_preflight_payload(status="passed", can_run_agents=True),
+            output_dir=persisted_dir,
+            attach_to_existing_run=True,
+        )
 
         assert persisted_dir == output_dir.resolve()
         assert (persisted_dir / "pipeline_result.json").exists()
+        assert preflight_path == persisted_dir / "preflight.json"
         run_metadata = _read_json(persisted_dir / "run_metadata.json")
         input_payload = _read_json(persisted_dir / "input_payload.json")
 
         assert run_metadata["run_id"] == "run-audit-001"
+        assert run_metadata["execution_status"] == "succeeded"
+        assert run_metadata["preflight"]["status"] == "passed"
         assert run_metadata["prompt_versions"]["monitor_tematico"]["monitor_tematico.query"] == "v1"
         assert input_payload["inputs"][0]["metadata"]["content"] == "brief text"
 
@@ -67,6 +86,64 @@ def test_persist_pipeline_result_writes_audit_trail_files() -> None:
         shutil.rmtree(workspace, ignore_errors=True)
 
 
+def test_blocked_preflight_attempt_is_auditable_without_agent_outputs() -> None:
+    workspace = _make_workspace()
+    try:
+        settings = load_settings(repo_root=workspace, env={}, env_file=workspace / ".env.missing")
+        output_dir, _ = persist_agent_preflight_audit(
+            settings=settings,
+            run_id="blocked-001",
+            as_of_date="2026-05-26",
+            generated_at="2026-05-26T10:00:00+02:00",
+            execution_status="blocked",
+            preflight=_preflight_payload(status="blocked", can_run_agents=False),
+        )
+
+        runs = ListAgentRunsUseCase(settings=settings).execute().runs
+        audit = GetAgentRunAuditUseCase(settings=settings).execute(
+            GetAgentRunAuditRequest(run_id="blocked-001")
+        )
+
+        assert output_dir.name == "blocked-001"
+        assert len(runs) == 1
+        assert runs[0].status == "blocked"
+        assert set(runs[0].agent_statuses.values()) == {"not_run"}
+        assert audit.preflight["status"] == "blocked"
+        assert audit.preflight["issues"][0]["code"] == "missing_prices"
+        assert not (output_dir / "pipeline_result.json").exists()
+        assert not (output_dir / "agents").exists()
+        assert all(not item["parsed_output"] for item in audit.agents.values())
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_blocked_preflight_does_not_mix_with_existing_output_directory() -> None:
+    workspace = _make_workspace()
+    try:
+        settings = load_settings(repo_root=workspace, env={}, env_file=workspace / ".env.missing")
+        requested_output_dir = workspace / "existing-audit"
+        requested_output_dir.mkdir()
+        sentinel = requested_output_dir / "keep.txt"
+        sentinel.write_text("existing", encoding="utf-8")
+
+        output_dir, _ = persist_agent_preflight_audit(
+            settings=settings,
+            run_id="blocked-002",
+            as_of_date="2026-05-26",
+            generated_at="2026-05-26T10:00:00+02:00",
+            execution_status="blocked",
+            preflight=_preflight_payload(status="blocked", can_run_agents=False),
+            output_dir=requested_output_dir,
+        )
+
+        assert output_dir == requested_output_dir / "blocked-002"
+        assert sentinel.read_text(encoding="utf-8") == "existing"
+        assert not (requested_output_dir / "run_metadata.json").exists()
+        assert (output_dir / "run_metadata.json").exists()
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
+
+
 def _agent_result(summary: str) -> AgentResult:
     return AgentResult(
         status="success",
@@ -77,6 +154,31 @@ def _agent_result(summary: str) -> AgentResult:
             "selected_actions": ("test_action",),
         },
     )
+
+
+def _preflight_payload(*, status: str, can_run_agents: bool) -> dict:
+    error_count = 0 if can_run_agents else 1
+    return {
+        "schema_version": 1,
+        "status": status,
+        "can_run_agents": can_run_agents,
+        "as_of_date": "2026-05-26",
+        "counts": {"error": error_count, "warning": 0, "info": int(can_run_agents)},
+        "issues": [
+            {
+                "code": "portfolio_metrics_ready" if can_run_agents else "missing_prices",
+                "severity": "info" if can_run_agents else "error",
+                "message": "ready" if can_run_agents else "missing",
+                "details": {},
+            }
+        ],
+        "inputs": {
+            "monthly_report_date": "2026-05-26",
+            "snapshot_as_of_date": "2026-05-26",
+            "min_valuation_coverage_ratio": 1.0,
+            "min_return_coverage_ratio": 0.8,
+        },
+    }
 
 
 def _make_workspace() -> Path:

--- a/tests/test_application_layer.py
+++ b/tests/test_application_layer.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import csv
+from dataclasses import replace
 from datetime import date
 import json
 from pathlib import Path
 import shutil
+from types import SimpleNamespace
 from uuid import uuid4
 
 import duckdb
@@ -46,6 +48,7 @@ from src.application import (
 )
 from src.application.serialization import json_ready_value
 from src.agents import AgentResult, MonthlyAgentPipelineResult
+from src.agents.pipeline import _persist_pipeline_result
 from src.config import default_repo_root, load_settings
 from src.degiro_exports.cash_movements import EXPECTED_ACCOUNT_HEADERS
 from src.degiro_exports.portfolio_snapshots import EXPECTED_PORTFOLIO_HEADERS
@@ -396,6 +399,7 @@ def test_agent_audit_use_cases_read_persisted_run() -> None:
         assert len(runs) == 1
         assert runs[0].run_id == "run-001"
         assert runs[0].status == "partial"
+        assert audit.preflight == {}
         assert audit.input_payload["inputs"][0]["key"] == "investment_brief"
         assert audit.agents["monitor_tematico"]["parsed_output"]["metadata"]["agent_plan"] == ["step"]
         assert audit.agents["monitor_tematico"]["prompt_rendered"] == "# prompt\n"
@@ -451,11 +455,16 @@ def test_run_monthly_agents_use_case_wraps_pipeline(monkeypatch) -> None:
     monkeypatch.setattr("src.application.agents.run_monthly_agent_pipeline", fake_pipeline)
     workspace = make_test_workspace()
     settings = load_settings(repo_root=workspace, env={})
+    report_path = workspace / "monthly_report_2026-05-26.md"
+    report_path.write_text("as_of_date: 2026-05-26\n", encoding="utf-8")
+    metrics = _agent_quality_metrics()
 
     try:
         result = RunMonthlyAgentsUseCase(settings=settings).execute(
             RunMonthlyAgentsRequest(
                 investment_brief_text="brief",
+                monthly_report_path=report_path,
+                metrics=metrics,
                 user_satellite_interest="semiconductors",
                 llm_provider="static",
                 search_provider="null",
@@ -469,11 +478,278 @@ def test_run_monthly_agents_use_case_wraps_pipeline(monkeypatch) -> None:
     assert captured["settings"] == settings
     assert captured["investment_brief_text"] == "brief"
     assert captured["user_satellite_interest"] == "semiconductors"
+    assert captured["metrics"] is metrics
     assert captured["persist"] is False
     assert captured["monthly_budget"] == 1500.0
     assert result.result.status == "partial"
+    assert result.quality_result.can_run_agents is True
     assert result.result.artifacts["run_id"] == "run-001"
     assert result.result.warnings == ("analista_activos: missing context",)
+
+
+def test_run_monthly_agents_blocks_before_pipeline_and_persists_attempt(monkeypatch) -> None:
+    pipeline_called = False
+
+    def fail_if_called(**_kwargs):
+        nonlocal pipeline_called
+        pipeline_called = True
+        raise AssertionError("Providers must not be reached after a blocking preflight.")
+
+    monkeypatch.setattr("src.application.agents.run_monthly_agent_pipeline", fail_if_called)
+    workspace = make_test_workspace()
+    settings = load_settings(repo_root=workspace, env={})
+    report_path = workspace / "monthly_report_2026-05-26.md"
+    report_path.write_text("as_of_date: 2026-05-26\n", encoding="utf-8")
+    output_dir = workspace / "blocked-audit"
+
+    try:
+        result = RunMonthlyAgentsUseCase(settings=settings).execute(
+            RunMonthlyAgentsRequest(
+                investment_brief_text="brief",
+                monthly_report_path=report_path,
+                metrics=_agent_quality_metrics(missing_price_positions_count=1),
+                portfolio_metrics_snapshot={"as_of_date": "2026-05-26"},
+                persist=True,
+                output_dir=output_dir,
+            )
+        )
+
+        assert pipeline_called is False
+        assert result.pipeline_result is None
+        assert result.result.status == "failed"
+        assert result.result.artifacts["execution_status"] == "blocked"
+        assert (output_dir / "preflight.json").exists()
+        assert (output_dir / "run_metadata.json").exists()
+        assert (output_dir / "input_payload.json").exists()
+        assert not (output_dir / "pipeline_result.json").exists()
+        assert not (output_dir / "agents").exists()
+        metadata = json.loads((output_dir / "run_metadata.json").read_text(encoding="utf-8"))
+        assert metadata["execution_status"] == "blocked"
+        assert {item["status"] for item in metadata["agents"].values()} == {"not_run"}
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_run_monthly_agents_continues_with_quality_warnings(monkeypatch) -> None:
+    def fake_pipeline(**kwargs):
+        return MonthlyAgentPipelineResult(
+            run_id="run-warning",
+            as_of_date=kwargs["metrics"].end_date,
+            input_refs=(),
+            monitor_tematico=AgentResult(status="success", summary="monitor ok"),
+            analista_activos=AgentResult(status="success", summary="analyst ok"),
+            asistente_aportacion_mensual=AgentResult(status="success", summary="assistant ok"),
+        )
+
+    monkeypatch.setattr("src.application.agents.run_monthly_agent_pipeline", fake_pipeline)
+    workspace = make_test_workspace()
+    settings = load_settings(repo_root=workspace, env={})
+    report_path = workspace / "monthly_report_2026-05-26.md"
+    report_path.write_text("as_of_date: 2026-05-26\n", encoding="utf-8")
+
+    try:
+        result = RunMonthlyAgentsUseCase(settings=settings).execute(
+            RunMonthlyAgentsRequest(
+                investment_brief_text="brief",
+                monthly_report_path=report_path,
+                metrics=_agent_quality_metrics(return_coverage_ratio=0.5),
+                portfolio_metrics_snapshot={"as_of_date": "2026-05-26"},
+                persist=False,
+            )
+        )
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
+
+    assert result.pipeline_result is not None
+    assert result.quality_result.result.status == "partial"
+    assert result.result.status == "partial"
+    assert result.result.warnings[0].startswith("quality_preflight:")
+
+
+def test_run_monthly_agents_persists_warning_preflight_on_allowed_run(monkeypatch) -> None:
+    workspace = make_test_workspace()
+    settings = load_settings(repo_root=workspace, env={})
+
+    def fake_pipeline(**kwargs):
+        pipeline_result = MonthlyAgentPipelineResult(
+            run_id="run-warning-persisted",
+            as_of_date=kwargs["metrics"].end_date,
+            input_refs=(),
+            monitor_tematico=AgentResult(status="success", summary="monitor ok"),
+            analista_activos=AgentResult(status="success", summary="analyst ok"),
+            asistente_aportacion_mensual=AgentResult(status="success", summary="assistant ok"),
+        )
+        output_dir = _persist_pipeline_result(
+            pipeline_result,
+            settings=kwargs["settings"],
+            output_dir=None,
+        )
+        return replace(pipeline_result, output_dir=output_dir)
+
+    monkeypatch.setattr("src.application.agents.run_monthly_agent_pipeline", fake_pipeline)
+    report_path = workspace / "monthly_report_2026-05-26.md"
+    report_path.write_text("as_of_date: 2026-05-26\n", encoding="utf-8")
+
+    try:
+        result = RunMonthlyAgentsUseCase(settings=settings).execute(
+            RunMonthlyAgentsRequest(
+                investment_brief_text="brief",
+                monthly_report_path=report_path,
+                metrics=_agent_quality_metrics(return_coverage_ratio=0.5),
+                portfolio_metrics_snapshot={"as_of_date": "2026-05-26"},
+                persist=True,
+            )
+        )
+        output_dir = result.pipeline_result.output_dir if result.pipeline_result else None
+        assert output_dir is not None
+        metadata = json.loads((output_dir / "run_metadata.json").read_text(encoding="utf-8"))
+        preflight = json.loads((output_dir / "preflight.json").read_text(encoding="utf-8"))
+        audit = GetAgentRunAuditUseCase(settings=settings).execute(
+            GetAgentRunAuditRequest(run_id="run-warning-persisted")
+        )
+
+        assert result.result.status == "partial"
+        assert preflight["status"] == "passed_with_warnings"
+        assert metadata["execution_status"] == "partial"
+        assert (output_dir / "pipeline_result.json").exists()
+        assert audit.preflight["counts"]["warning"] == 1
+        assert audit.agents["monitor_tematico"]["parsed_output"]["status"] == "success"
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_run_monthly_agents_blocks_misaligned_dates_before_pipeline(monkeypatch) -> None:
+    def fail_if_called(**_kwargs):
+        raise AssertionError("The pipeline must not run with misaligned input dates.")
+
+    monkeypatch.setattr("src.application.agents.run_monthly_agent_pipeline", fail_if_called)
+    workspace = make_test_workspace()
+    settings = load_settings(repo_root=workspace, env={})
+    report_path = workspace / "monthly_report_2026-05-25.md"
+    report_path.write_text("as_of_date: 2026-05-25\n", encoding="utf-8")
+
+    try:
+        result = RunMonthlyAgentsUseCase(settings=settings).execute(
+            RunMonthlyAgentsRequest(
+                investment_brief_text="brief",
+                monthly_report_path=report_path,
+                metrics=_agent_quality_metrics(),
+                portfolio_metrics_snapshot={"as_of_date": "2026-05-26"},
+                persist=False,
+            )
+        )
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
+
+    issue_codes = {issue.code for issue in result.quality_result.report.issues}
+    assert result.pipeline_result is None
+    assert result.result.status == "failed"
+    assert "monthly_report_date_mismatch" in issue_codes
+    assert "monthly_report_snapshot_date_mismatch" in issue_codes
+
+
+def test_run_monthly_agents_blocks_selected_report_without_date(monkeypatch) -> None:
+    def fail_if_called(**_kwargs):
+        raise AssertionError("The pipeline must not run with an undated selected report.")
+
+    monkeypatch.setattr("src.application.agents.run_monthly_agent_pipeline", fail_if_called)
+    workspace = make_test_workspace()
+    settings = load_settings(repo_root=workspace, env={})
+    report_path = workspace / "monthly_report_without_date.md"
+    report_path.write_text("# Monthly report without metadata\n", encoding="utf-8")
+
+    try:
+        result = RunMonthlyAgentsUseCase(settings=settings).execute(
+            RunMonthlyAgentsRequest(
+                investment_brief_text="brief",
+                monthly_report_path=report_path,
+                metrics=_agent_quality_metrics(),
+                portfolio_metrics_snapshot={"as_of_date": "2026-05-26"},
+                persist=False,
+            )
+        )
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
+
+    assert result.pipeline_result is None
+    assert "monthly_report_date_missing" in {
+        issue.code for issue in result.quality_result.report.issues
+    }
+
+
+def test_run_monthly_agents_uses_latest_report_content_date_for_preflight(monkeypatch) -> None:
+    def fail_if_called(**_kwargs):
+        raise AssertionError("Stale report metadata must not bypass the content date.")
+
+    monkeypatch.setattr("src.application.agents.run_monthly_agent_pipeline", fail_if_called)
+    workspace = make_test_workspace()
+    settings = load_settings(repo_root=workspace, env={})
+    report_path = workspace / "latest_monthly_report.md"
+    report_path.write_text("as_of_date: 2026-05-25\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "src.application.agents.get_latest_monthly_report",
+        lambda **_kwargs: SimpleNamespace(
+            report_path=report_path,
+            as_of_date=date(2026, 5, 26),
+        ),
+    )
+
+    try:
+        result = RunMonthlyAgentsUseCase(settings=settings).execute(
+            RunMonthlyAgentsRequest(
+                investment_brief_text="brief",
+                metrics=_agent_quality_metrics(),
+                portfolio_metrics_snapshot={"as_of_date": "2026-05-26"},
+                persist=False,
+            )
+        )
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
+
+    assert result.pipeline_result is None
+    assert "monthly_report_date_mismatch" in {
+        issue.code for issue in result.quality_result.report.issues
+    }
+
+
+def _agent_quality_metrics(
+    *,
+    return_coverage_ratio: float = 1.0,
+    missing_price_positions_count: int = 0,
+) -> PortfolioMetricsResult:
+    total_positions_count = 1
+    valued_positions_count = total_positions_count - missing_price_positions_count
+    daily = pd.DataFrame(
+        [
+            {
+                "valuation_date": date(2026, 5, 26),
+                "total_positions_count": total_positions_count,
+                "valued_positions_count": valued_positions_count,
+                "missing_price_positions_count": missing_price_positions_count,
+                "missing_fx_positions_count": 0,
+                "valuation_coverage_ratio": float(valued_positions_count),
+                "return_coverage_ratio": return_coverage_ratio,
+                "total_market_value_base": 1000.0,
+            }
+        ]
+    )
+    positions = pd.DataFrame(
+        [
+            {
+                "valuation_date": date(2026, 5, 26),
+                "asset_id": "asset-1",
+                "asset_name": "Asset 1",
+                "market_value_base": 1000.0,
+            }
+        ]
+    )
+    return PortfolioMetricsResult(
+        start_date=date(2026, 5, 26),
+        end_date=date(2026, 5, 26),
+        base_currency="EUR",
+        position_metrics=positions,
+        portfolio_daily_metrics=daily,
+    )
 
 
 def _read_warehouse_snapshot(db_path: Path) -> dict[str, object]:

--- a/tests/test_data_quality.py
+++ b/tests/test_data_quality.py
@@ -57,6 +57,24 @@ def test_agent_quality_blocks_inconsistent_report_and_snapshot_dates() -> None:
     assert "monthly_report_snapshot_date_mismatch" in {issue.code for issue in report.issues}
 
 
+def test_agent_quality_returns_structured_error_for_invalid_snapshot_date() -> None:
+    metrics = _metrics_result(
+        valuation_coverage_ratio=1.0,
+        return_coverage_ratio=1.0,
+        missing_price_positions_count=0,
+        missing_fx_positions_count=0,
+    )
+
+    report = check_agent_input_quality(
+        metrics=metrics,
+        monthly_report_date=date(2026, 5, 26),
+        portfolio_metrics_snapshot={"as_of_date": "not-a-date"},
+    )
+
+    assert report.can_run_agents is False
+    assert "snapshot_date_missing" in {issue.code for issue in report.issues}
+
+
 def test_run_agent_quality_checks_use_case_returns_application_result() -> None:
     metrics = _metrics_result(
         valuation_coverage_ratio=1.0,
@@ -73,9 +91,34 @@ def test_run_agent_quality_checks_use_case_returns_application_result() -> None:
     )
 
     assert result.can_run_agents is True
-    assert result.result.status == "succeeded"
+    assert result.result.status == "partial"
     assert result.report.warning_count == 1
     assert result.result.warnings
+    assert result.to_dict()["status"] == "passed_with_warnings"
+
+
+def test_run_agent_quality_checks_use_case_returns_failed_for_blocking_issue() -> None:
+    metrics = _metrics_result(
+        valuation_coverage_ratio=0.0,
+        return_coverage_ratio=1.0,
+        missing_price_positions_count=1,
+        missing_fx_positions_count=0,
+    )
+
+    result = RunAgentQualityChecksUseCase().execute(
+        RunAgentQualityChecksRequest(
+            metrics=metrics,
+            monthly_report_date=date(2026, 5, 26),
+            portfolio_metrics_snapshot={"as_of_date": "2026-05-26"},
+        )
+    )
+
+    payload = result.to_dict()
+    assert result.can_run_agents is False
+    assert result.result.status == "failed"
+    assert payload["status"] == "blocked"
+    assert payload["counts"]["error"] >= 1
+    assert "missing_prices" in {issue["code"] for issue in payload["issues"]}
 
 
 def _metrics_result(

--- a/tests/test_run_monthly_agents_cli.py
+++ b/tests/test_run_monthly_agents_cli.py
@@ -1,0 +1,155 @@
+from argparse import Namespace
+from datetime import date
+from types import SimpleNamespace
+
+from src.agents import AgentResult
+from src.application import ApplicationResult
+
+import scripts.run_monthly_agents as cli
+
+
+def test_cli_returns_non_zero_when_quality_preflight_blocks(monkeypatch, capsys) -> None:
+    preflight = {
+        "status": "blocked",
+        "as_of_date": "2026-05-26",
+        "counts": {"error": 1, "warning": 0, "info": 0},
+        "issues": [
+            {
+                "severity": "error",
+                "code": "missing_prices",
+                "message": "Missing prices.",
+            }
+        ],
+    }
+    use_case_result = SimpleNamespace(
+        quality_result=SimpleNamespace(to_dict=lambda: preflight),
+        pipeline_result=None,
+        result=ApplicationResult(
+            name="run_monthly_agents",
+            status="failed",
+            message="Monthly agents blocked by quality preflight: missing_prices.",
+            artifacts={"output_dir": "audit/run-001"},
+        ),
+    )
+
+    class FakeUseCase:
+        def __init__(self, **_kwargs) -> None:
+            pass
+
+        def execute(self, _request):
+            return use_case_result
+
+    monkeypatch.setattr(cli, "RunMonthlyAgentsUseCase", FakeUseCase)
+    monkeypatch.setattr(cli, "get_settings", lambda: object())
+    monkeypatch.setattr(
+        cli,
+        "parse_args",
+        lambda: Namespace(
+            investment_brief_file=None,
+            investment_brief_text=None,
+            monthly_report=None,
+            user_satellite_interest=None,
+            llm_provider="static",
+            search_provider="null",
+            no_persist=False,
+            output_dir=None,
+        ),
+    )
+
+    exit_code = cli.main()
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "Preflight: blocked" in output
+    assert "missing_prices" in output
+    assert "Audit: audit/run-001" in output
+
+
+def test_cli_returns_zero_when_preflight_warning_allows_pipeline(monkeypatch, capsys) -> None:
+    pipeline_result = _pipeline_result()
+    use_case_result = SimpleNamespace(
+        quality_result=SimpleNamespace(
+            to_dict=lambda: {
+                "status": "passed_with_warnings",
+                "as_of_date": "2026-05-26",
+                "counts": {"error": 0, "warning": 1, "info": 0},
+                "issues": [
+                    {
+                        "severity": "warning",
+                        "code": "return_coverage_below_threshold",
+                        "message": "Return coverage is incomplete.",
+                    }
+                ],
+            }
+        ),
+        pipeline_result=pipeline_result,
+        result=ApplicationResult(name="run_monthly_agents", status="partial"),
+    )
+    _stub_cli(monkeypatch, use_case_result)
+
+    exit_code = cli.main()
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "Preflight: passed_with_warnings" in output
+    assert "Run: run-001" in output
+
+
+def test_cli_returns_non_zero_when_an_agent_fails(monkeypatch, capsys) -> None:
+    pipeline_result = _pipeline_result(agent_status="failed")
+    use_case_result = SimpleNamespace(
+        quality_result=SimpleNamespace(
+            to_dict=lambda: {
+                "status": "passed",
+                "as_of_date": "2026-05-26",
+                "counts": {"error": 0, "warning": 0, "info": 1},
+                "issues": [],
+            }
+        ),
+        pipeline_result=pipeline_result,
+        result=ApplicationResult(name="run_monthly_agents", status="failed"),
+    )
+    _stub_cli(monkeypatch, use_case_result)
+
+    exit_code = cli.main()
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "monitor_tematico: failed" in output
+
+
+def _stub_cli(monkeypatch, use_case_result) -> None:
+    class FakeUseCase:
+        def __init__(self, **_kwargs) -> None:
+            pass
+
+        def execute(self, _request):
+            return use_case_result
+
+    monkeypatch.setattr(cli, "RunMonthlyAgentsUseCase", FakeUseCase)
+    monkeypatch.setattr(cli, "get_settings", lambda: object())
+    monkeypatch.setattr(
+        cli,
+        "parse_args",
+        lambda: Namespace(
+            investment_brief_file=None,
+            investment_brief_text=None,
+            monthly_report=None,
+            user_satellite_interest=None,
+            llm_provider="static",
+            search_provider="null",
+            no_persist=False,
+            output_dir=None,
+        ),
+    )
+
+
+def _pipeline_result(*, agent_status: str = "success"):
+    return SimpleNamespace(
+        run_id="run-001",
+        as_of_date=date(2026, 5, 26),
+        output_dir=None,
+        monitor_tematico=AgentResult(status=agent_status, summary="monitor"),
+        analista_activos=AgentResult(status="success", summary="analyst"),
+        asistente_aportacion_mensual=AgentResult(status="success", summary="assistant"),
+    )


### PR DESCRIPTION
## Resumen
- ejecuta quality checks antes de providers
- audita runs permitidos e intentos bloqueados
- alinea CLI, Streamlit y documentacion

## Validacion
- 176 tests
- cobertura 73,44%
- Ruff y mypy OK

Closes #39