### PR TITLE
Auditoría reproducible de agentes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,9 @@ La UI actual es Streamlit. Una futura API/FastAPI debe entrar casi siempre por `
 - No metas logica de UI en dominio ni queries/repositorios directos en Streamlit si existe caso de uso equivalente.
 - Los datos de cartera salen de exportaciones oficiales DEGIRO y artefactos derivados validados. Los agentes no deben inventar estado de cartera.
 - Preserva auditoria de agentes: plan interno, acciones permitidas/usadas/descartadas, fuentes, prompts, warnings, inputs y outputs.
+- Si cambias la auditoria, conserva lectura legacy, JSON estricto, hashes
+  semanticos y provider metadata allowlisted; nunca persistas credenciales,
+  cabeceras de autorizacion, variables de entorno ni clientes SDK.
 - Si cambia comportamiento de agentes, actualiza tests y, cuando aplique, prompts versionados o documentacion de agentes.
 - Si cambias comandos documentados, valida que siguen existiendo.
 - Si tocas docs, evita duplicar manuales largos: enlaza a `docs/` o README de dominio.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ proyecto usa [versionado semántico](https://semver.org/lang/es/).
 - Providers `synthetic` de precios y FX que mantienen la demo completamente
   offline, además de búsqueda `static` determinista para agentes.
 - Auditoría `preflight.json` para runs permitidos e intentos bloqueados.
+- Auditoría reproducible de agentes con requests y contextos efectivos,
+  providers allowlisted, respuestas raw trazables y hashes semánticos.
 
 ### Cambiado
 
@@ -55,6 +57,8 @@ proyecto usa [versionado semántico](https://semver.org/lang/es/).
 
 - Actualizada la dependencia de datos de mercado `yfinance` a `1.5.2`.
 - Añadidos escaneos de archivos versionados y dependencias a la CI.
+- La auditoría de providers excluye credenciales y redacta claves sensibles
+  antes de persistir o mostrar respuestas raw.
 
 ## [0.1.0] - 2026-06-23
 

--- a/docs/monthly_pipeline.md
+++ b/docs/monthly_pipeline.md
@@ -59,6 +59,28 @@ necesariamente la fecha del snapshot.
   `input_payload.json` y `agents/<agent_name>/...`
 - Overrides temporales de informes para agentes: `src/data/local/agents/input_overrides/latest_monthly_report_override_YYYY-MM-DD.md`
 
+### Auditoria reproducible
+
+El schema v2 persiste la peticion y el contexto efectivos de cada agente. El
+`request.json` conserva `scope`, `parameters`, `constraints`, `metadata` e
+`input_refs`; estas referencias se resuelven contra el contexto real, por lo que
+analista y asistente incluyen tambien resultados de agentes anteriores.
+
+Cada directorio de agente añade `provider.json` y `audit_metadata.json`.
+`provider.json` contiene solo provider, modelo y opciones allowlisted; no
+incluye credenciales, cabeceras, variables de entorno ni clientes SDK.
+`raw_response.json` usa `captured`, `partial` o `not_captured` y un
+`reason_code` estable cuando la captura no es completa.
+
+Los hashes SHA-256 se calculan sobre JSON canonico y contenido semantico. Los
+hashes de entrada excluyen ids de run y timestamps volatiles; los de salida
+representan la salida parseada. Sirven para detectar cambios reproducibles, no
+para anonimizar datos ni validar una recomendacion.
+
+Los runs sin `schema_version` o sin los artefactos nuevos son legacy v1.
+`GetAgentRunAuditUseCase` y Streamlit los leen sin reescribirlos y muestran como
+no disponible la metadata que no existia entonces.
+
 ## Notas operativas
 
 - `import_degiro.py` carga por defecto los parquets normalizados a DuckDB.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -30,6 +30,34 @@ Los datos de ejemplo que se publiquen deben ser sinteticos o estar saneados de
 forma que no permitan reconstruir la cartera real, importes, fechas exactas o
 decisiones personales.
 
+## Auditoria de agentes
+
+La auditoria reproducible conserva mas detalle que un log convencional. En
+particular, `request.json`, `context.json`, `prompt_rendered.md`,
+`raw_response.json` y `parsed_output.json` pueden contener el brief, posiciones,
+presupuesto, objetivos, respuestas del provider y decisiones derivadas. Deben
+tratarse siempre como datos financieros privados.
+
+El schema v2 añade `provider.json` y hashes SHA-256. La configuracion del
+provider se construye mediante una lista permitida de campos no secretos:
+nombre, modelo y opciones operativas necesarias para interpretar el run. No
+debe persistir API keys, tokens, passwords, cookies, cabeceras de autorizacion,
+variables de entorno ni objetos cliente de un SDK.
+
+Una respuesta raw puede quedar `captured`, `partial` o `not_captured`. Cuando se
+captura, puede incluir texto completo de salida, identificadores del provider y
+metricas de uso. Que no contenga una credencial no la convierte en publica:
+puede revelar indirectamente los inputs financieros enviados.
+
+Los `input_hash` y `output_hash` sirven para detectar cambios semanticos e
+integridad entre ejecuciones. Un hash no anonimiza sus datos de origen, no
+demuestra que dos decisiones sean correctas y no hace seguro publicar el
+artefacto que lo contiene.
+
+Los runs legacy v1 siguen siendo privados aunque no incluyan provider metadata,
+hashes o respuesta raw capturable. La lectura compatible no reescribe esos
+artefactos ni elimina posibles datos sensibles que ya contengan.
+
 ## Rutas privadas
 
 Estas rutas estan disenadas para uso local y deben permanecer fuera de Git:
@@ -122,6 +150,11 @@ historial afectado antes de considerar el repositorio seguro.
   demo sintetica revisada.
 - Los informes y outputs de agentes usados en demos proceden de datos sinteticos
   o saneados.
+- Los `provider.json` revisados no contienen claves, tokens, cabeceras ni
+  variables de entorno.
+- Los `raw_response.json` y prompts usados en capturas proceden de la demo
+  sintetica y se han revisado manualmente.
+- No se considera un audit trail publicable solo porque incluya hashes.
 - El diff no contiene rutas locales absolutas, claves API, tokens ni datos de
   cartera real.
 - Si se han usado proveedores externos, los prompts y respuestas no incluyen
@@ -145,3 +178,7 @@ En la v1 local con Streamlit hay dos combinaciones offline:
 Los proveedores `openai`, `tavily` y `duckduckgo` deben tratarse como
 ejecuciones reales o semi-reales, porque pueden sacar informacion fuera del
 equipo local.
+
+Si una credencial aparece por error en un audit trail, deja de compartirlo,
+elimina la copia afectada y rota la credencial en el proveedor. Ocultarla en
+Streamlit o sustituirla solo en una captura no invalida el secreto original.

--- a/docs/streamlit_dashboard.md
+++ b/docs/streamlit_dashboard.md
@@ -112,9 +112,11 @@ La pestana `Agentes` incluye un bloque `Auditoria de agentes` para revisar runs
 persistidos en `src/data/local/agents/monthly_pipeline/<run_id>/` o en el
 directorio demo equivalente. Esta vista permite inspeccionar:
 
-- estado del run, preflight de calidad, fechas, inputs y versiones de prompts;
+- estado del run, version del esquema, preflight de calidad, fechas, inputs y
+  versiones de prompts;
 - plan interno, acciones permitidas, acciones usadas, acciones descartadas y
   base de decision de cada agente;
+- request efectiva, provider/modelo/opciones allowlisted y hashes SHA-256;
 - warnings y errores;
 - findings, artifacts y metadata completa;
 - fuentes citadas por agente y por finding;
@@ -122,12 +124,23 @@ directorio demo equivalente. Esta vista permite inspeccionar:
 - inputs efectivos recibidos por cada agente;
 - request y raw response guardada.
 
-La `raw_response` puede aparecer como `not_captured` porque los proveedores
-actuales devuelven objetos de dominio ya parseados. Si mas adelante interesa
-auditar la respuesta bruta del LLM, habra que ampliar el contrato de providers.
+La pestaña `Raw` diferencia `captured`, `partial` y `not_captured`; un
+`reason_code` estable explica por que falta alguna respuesta, por ejemplo cuando
+el contrato del provider solo entrega un objeto de dominio ya parseado. Aunque
+la vista muestre provider y modelo, la proyeccion excluye credenciales,
+cabeceras de autorizacion, variables de entorno y clientes SDK. La respuesta raw
+sigue siendo privada y se muestra como detalle de auditoria, no como contenido
+apto para capturas publicas.
+
 Los intentos bloqueados persistidos tambien aparecen en la lista con estado
 `blocked`. Incluyen metadata, inputs y preflight, pero no `pipeline_result.json`,
 outputs ni tabs de agentes vacios.
+
+Los hashes comparan el contenido semantico persistido: inputs efectivos,
+request, prompts y provider para entrada; salida parseada para output. No
+anonimizan la cartera. Los runs legacy v1, que no contienen todos estos campos,
+siguen abriendo sin migracion; la UI indica que la metadata ausente no estaba
+disponible en ese esquema.
 
 Al guardar desde la UI, el dashboard detecta el tipo de exportacion por el
 nombre del archivo y lo copia a `incoming` con el nombre canonico que exige el

--- a/src/agents/README.md
+++ b/src/agents/README.md
@@ -115,6 +115,13 @@ Campos principales:
 - `parameters`: configuracion especifica del agente.
 - `constraints`: limites o reglas de usuario.
 - `input_refs`: claves de entradas del contexto que la peticion solicita consumir.
+- `metadata`: contexto adicional de la peticion que no forma parte del dominio.
+
+En una ejecucion persistida, cada `request.json` contiene la peticion efectiva
+de ese agente. Conserva `scope`, `parameters`, `constraints` y `metadata`, y
+resuelve `input_refs` contra las entradas realmente disponibles en su contexto.
+Por eso los tres agentes de un mismo run pueden tener referencias distintas:
+los agentes posteriores reciben tambien los resultados de los anteriores.
 
 ### `AgentResult`
 
@@ -217,16 +224,49 @@ Cada ejecucion persistida de la pipeline mensual escribe un directorio privado
 en `src/data/local/agents/monthly_pipeline/<run_id>/`. Ademas de
 `pipeline_result.json`, se guardan:
 
-- `run_metadata.json`: fecha, moneda base, estados por agente y versiones de prompts.
+- `run_metadata.json`: version de esquema, fecha, moneda base, estados,
+  providers, hashes agregados y versiones de prompts.
 - `preflight.json`: resultado, codigos, severidades y conteos de calidad.
-- `input_payload.json`: referencias de entrada completas usadas en el run.
+- `input_payload.json`: referencias de entrada completas y hash agregado del
+  run.
 - `agents/<agent_name>/context.json`: contexto efectivo del agente.
-- `agents/<agent_name>/request.json`: request estructurada enviada al agente.
+- `agents/<agent_name>/request.json`: request efectiva enviada al agente,
+  incluidos alcance, parametros, restricciones y referencias de entrada.
 - `agents/<agent_name>/prompt_refs.json`: claves y versiones de prompts.
 - `agents/<agent_name>/prompt_rendered.md`: prompt versionado usado en esa ejecucion.
-- `agents/<agent_name>/raw_response.json`: placeholder con estado
-  `not_captured` mientras el contrato LLM no expone la respuesta bruta.
+- `agents/<agent_name>/provider.json`: nombre, modelo y opciones operativas
+  permitidas por una lista explicita; nunca credenciales.
+- `agents/<agent_name>/raw_response.json`: respuestas que el contrato del
+  provider permite capturar y el motivo estable de cualquier ausencia.
 - `agents/<agent_name>/parsed_output.json`: salida estructurada parseada.
+- `agents/<agent_name>/audit_metadata.json`: version de esquema y hashes
+  semanticos de entrada y salida.
+
+El run y los envelopes de auditoria nuevos usan `schema_version: 2`.
+`request.json` conserva deliberadamente solo los cinco campos de
+`AgentRequest`, para permitir su round-trip directo, y hereda la version del
+run. `raw_response.json` distingue:
+
+- `captured`: se conservaron todas las respuestas raw disponibles;
+- `partial`: solo algunas operaciones o providers ofrecieron respuesta raw;
+- `not_captured`: no habia respuesta raw accesible; `reason_code` explica el
+  motivo de forma estable.
+
+La configuracion de provider es una proyeccion segura y allowlisted. Registra
+provider, modelo y opciones relevantes para reproducibilidad, pero no guarda
+API keys, tokens, cabeceras de autorizacion, variables de entorno ni el cliente
+del SDK.
+
+Los hashes usan SHA-256 sobre JSON canonico. El `input_hash` representa el
+contexto y request efectivos, prompts y configuracion no secreta del provider;
+excluye identificadores y timestamps volatiles. El `output_hash` representa la
+salida parseada. Son huellas para comparar integridad y cambios semanticos, no
+una prueba de equivalencia financiera ni un mecanismo de anonimato.
+
+Los runs anteriores sin `schema_version`, `provider.json`,
+`audit_metadata.json` o hashes se leen como auditorias legacy v1. No se
+reescriben ni migran al abrirlos; Streamlit muestra lo disponible y marca como
+ausente la metadata que la version antigua nunca persistio.
 
 Estos artefactos viven bajo `src/data/local/`, por tanto son privados y estan
 ignorados por Git. Para demos publicas deben usarse datos sinteticos.

--- a/src/agents/analista_activos/llm.py
+++ b/src/agents/analista_activos/llm.py
@@ -10,6 +10,10 @@ from typing import Any, Protocol
 
 from dotenv import dotenv_values
 
+from src.agents.provider_audit import (
+    record_provider_failure,
+    record_provider_raw_response,
+)
 from src.agents.prompts import load_prompt
 from src.agents.analista_activos._types import (
     AssetAnalysis,
@@ -210,8 +214,10 @@ class OpenAIAssetLLMProvider:
                 },
             )
         except Exception as exc:
+            record_provider_failure(self, operation=schema_name)
             raise AssetLLMProviderError(f"OpenAI request failed: {exc}") from exc
 
+        record_provider_raw_response(self, response, operation=schema_name)
         text = getattr(response, "output_text", None)
         if not text:
             raise AssetLLMProviderError("OpenAI response did not include output_text.")

--- a/src/agents/asistente_aportacion_mensual/llm.py
+++ b/src/agents/asistente_aportacion_mensual/llm.py
@@ -10,6 +10,10 @@ from typing import Any, Mapping, Protocol
 
 from dotenv import dotenv_values
 
+from src.agents.provider_audit import (
+    record_provider_failure,
+    record_provider_raw_response,
+)
 from src.agents.prompts import load_prompt
 from src.agents.asistente_aportacion_mensual._types import (
     MonthlyDecision,
@@ -304,8 +308,10 @@ class OpenAIContributionLLMProvider:
                 },
             )
         except Exception as exc:
+            record_provider_failure(self, operation=schema_name)
             raise ContributionLLMProviderError(f"OpenAI request failed: {exc}") from exc
 
+        record_provider_raw_response(self, response, operation=schema_name)
         text = getattr(response, "output_text", None)
         if not text:
             raise ContributionLLMProviderError("OpenAI response did not include output_text.")

--- a/src/agents/monitor_tematico/llm.py
+++ b/src/agents/monitor_tematico/llm.py
@@ -20,6 +20,10 @@ from typing import Any, Protocol
 
 from dotenv import dotenv_values
 
+from src.agents.provider_audit import (
+    record_provider_failure,
+    record_provider_raw_response,
+)
 from src.agents.prompts import load_prompt
 from src.agents.monitor_tematico._types import (
     LLMSearchQuery,
@@ -318,8 +322,10 @@ class OpenAIThemeLLMProvider:
                 },
             )
         except Exception as exc:
+            record_provider_failure(self, operation=schema_name)
             raise ThemeLLMProviderError(f"OpenAI request failed: {exc}") from exc
 
+        record_provider_raw_response(self, response, operation=schema_name)
         text = getattr(response, "output_text", None)
         if not text:
             raise ThemeLLMProviderError("OpenAI response did not include output_text.")

--- a/src/agents/monitor_tematico/providers.py
+++ b/src/agents/monitor_tematico/providers.py
@@ -25,6 +25,7 @@ from urllib.request import Request, urlopen
 from dotenv import dotenv_values
 
 from src.agents.monitor_tematico._types import SearchResult
+from src.agents.provider_audit import record_provider_failure
 
 
 class SearchProvider(Protocol):
@@ -162,6 +163,7 @@ class DuckDuckGoHtmlSearchProvider:
             with urlopen(request, timeout=self.timeout_seconds) as response:
                 raw_html = response.read().decode("utf-8", errors="replace")
         except OSError as exc:
+            record_provider_failure(self, operation="search")
             raise SearchProviderError(f"{self.name} failed for query {query!r}: {exc}") from exc
 
         parser = _DuckDuckGoHtmlParser(query=query)
@@ -203,6 +205,11 @@ class TavilySearchProvider:
         max_results: int,
     ) -> tuple[SearchResult, ...]:
         if not self.api_key:
+            record_provider_failure(
+                self,
+                operation="search",
+                reason_code="provider_configuration_missing",
+            )
             raise SearchProviderError("TAVILY_API_KEY is required when using the tavily search provider.")
 
         payload = {
@@ -226,15 +233,26 @@ class TavilySearchProvider:
             with urlopen(request, timeout=self.timeout_seconds) as response:
                 raw_payload = response.read().decode("utf-8", errors="replace")
         except OSError as exc:
+            record_provider_failure(self, operation="search")
             raise SearchProviderError(f"{self.name} failed for query {query!r}: {exc}") from exc
 
         try:
             data = json.loads(raw_payload)
         except json.JSONDecodeError as exc:
+            record_provider_failure(
+                self,
+                operation="search",
+                reason_code="provider_response_invalid",
+            )
             raise SearchProviderError(f"{self.name} returned invalid JSON for query {query!r}.") from exc
 
         raw_results = data.get("results", [])
         if not isinstance(raw_results, list):
+            record_provider_failure(
+                self,
+                operation="search",
+                reason_code="provider_response_invalid",
+            )
             raise SearchProviderError(f"{self.name} response did not include a valid results list.")
 
         results: list[SearchResult] = []

--- a/src/agents/pipeline.py
+++ b/src/agents/pipeline.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, is_dataclass, replace
+from dataclasses import asdict, dataclass, field, is_dataclass, replace
 from datetime import date, datetime
+import hashlib
 import json
+from math import isfinite
 from pathlib import Path
 import re
 from typing import Any, Mapping
@@ -17,7 +19,12 @@ from src.agents.asistente_aportacion_mensual import (
     OpenAIContributionLLMProvider,
     StaticContributionLLMProvider,
 )
-from src.agents.models import AgentInputRef, AgentRequest, AgentResult, build_agent_context
+from src.agents.models import AgentContext, AgentInputRef, AgentRequest, AgentResult, build_agent_context
+from src.agents.provider_audit import (
+    provider_audit_config,
+    providers_raw_response_audit,
+    redact_sensitive_audit_payload,
+)
 from src.agents.prompts import load_prompt, prompt_version
 from src.agents.monitor_tematico import (
     DuckDuckGoHtmlSearchProvider,
@@ -35,6 +42,9 @@ from src.portfolio.targets import PortfolioTargets, load_portfolio_targets
 from src.reports import generate_monthly_report, get_latest_monthly_report
 
 
+AUDIT_SCHEMA_VERSION = 2
+
+
 @dataclass(frozen=True)
 class MonthlyAgentPipelineResult:
     """Results and persisted artifact paths for one monthly agent pipeline run."""
@@ -46,6 +56,11 @@ class MonthlyAgentPipelineResult:
     analista_activos: AgentResult
     asistente_aportacion_mensual: AgentResult
     output_dir: Path | None = None
+    agent_requests: Mapping[str, AgentRequest] = field(default_factory=dict)
+    agent_contexts: Mapping[str, Mapping[str, Any]] = field(default_factory=dict)
+    prompt_audits: Mapping[str, Mapping[str, Any]] = field(default_factory=dict)
+    provider_configs: Mapping[str, Mapping[str, Any]] = field(default_factory=dict)
+    raw_responses: Mapping[str, Mapping[str, Any]] = field(default_factory=dict)
 
 
 def run_monthly_agent_pipeline(
@@ -60,7 +75,10 @@ def run_monthly_agent_pipeline(
     search_provider: str = "null",
     persist: bool = True,
     output_dir: str | Path | None = None,
+    request_scope: Mapping[str, Any] | None = None,
     request_parameters: Mapping[str, Any] | None = None,
+    request_constraints: Mapping[str, Any] | None = None,
+    request_metadata: Mapping[str, Any] | None = None,
     portfolio_metrics_snapshot: Mapping[str, Any] | None = None,
     monthly_budget: float | None = None,
 ) -> MonthlyAgentPipelineResult:
@@ -105,11 +123,29 @@ def run_monthly_agent_pipeline(
         portfolio_targets=portfolio_targets,
         portfolio_targets_location=str(resolved_settings.portfolio_targets_path),
     )
-    request = AgentRequest(parameters=dict(request_parameters or {}))
+    base_request = AgentRequest(
+        scope=dict(request_scope or {}),
+        parameters=dict(request_parameters or {}),
+        constraints=dict(request_constraints or {}),
+        metadata=dict(request_metadata or {}),
+    )
+    # Snapshot prompts before execution so the audit cannot drift if files change mid-run.
+    prompt_audits = {
+        agent_name: {
+            "prompt_refs": {
+                "schema_version": AUDIT_SCHEMA_VERSION,
+                **_agent_prompt_refs(agent_name),
+            },
+            "prompt_rendered": _agent_prompt_markdown(agent_name),
+        }
+        for agent_name in _agent_prompt_keys()
+    }
 
+    monitor_search_provider = _build_search_provider(search_provider)
+    monitor_llm_provider = _build_monitor_llm_provider(llm_provider)
     monitor_agent = MonitorTematicoAgent(
-        search_provider=_build_search_provider(search_provider),
-        llm_provider=_build_monitor_llm_provider(llm_provider),
+        search_provider=monitor_search_provider,
+        llm_provider=monitor_llm_provider,
     )
     monitor_context = build_agent_context(
         agent_name=monitor_agent.name,
@@ -120,10 +156,12 @@ def run_monthly_agent_pipeline(
         input_refs=common_refs,
         run_id=run_id,
     )
-    monitor_result = monitor_agent.execute(request, monitor_context)
+    monitor_request = _request_for_context(base_request, monitor_context)
+    monitor_result = monitor_agent.execute(monitor_request, monitor_context)
 
     monitor_ref = _result_input_ref("monitor_tematico_result", "Monitor tematico result", monitor_result)
-    analista_agent = AnalistaActivosAgent(llm_provider=_build_asset_llm_provider(llm_provider))
+    analista_llm_provider = _build_asset_llm_provider(llm_provider)
+    analista_agent = AnalistaActivosAgent(llm_provider=analista_llm_provider)
     analista_context = build_agent_context(
         agent_name=analista_agent.name,
         as_of_date=as_of_date,
@@ -133,12 +171,12 @@ def run_monthly_agent_pipeline(
         input_refs=(*common_refs, monitor_ref),
         run_id=run_id,
     )
-    analista_result = analista_agent.execute(request, analista_context)
+    analista_request = _request_for_context(base_request, analista_context)
+    analista_result = analista_agent.execute(analista_request, analista_context)
 
     analista_ref = _result_input_ref("analista_activos_result", "Analista activos result", analista_result)
-    asistente_agent = AsistenteAportacionMensualAgent(
-        llm_provider=_build_contribution_llm_provider(llm_provider),
-    )
+    asistente_llm_provider = _build_contribution_llm_provider(llm_provider)
+    asistente_agent = AsistenteAportacionMensualAgent(llm_provider=asistente_llm_provider)
     asistente_context = build_agent_context(
         agent_name=asistente_agent.name,
         as_of_date=as_of_date,
@@ -159,7 +197,43 @@ def run_monthly_agent_pipeline(
         },
         run_id=run_id,
     )
-    asistente_result = asistente_agent.execute(request, asistente_context)
+    asistente_request = _request_for_context(base_request, asistente_context)
+    asistente_result = asistente_agent.execute(asistente_request, asistente_context)
+
+    agent_requests = {
+        "monitor_tematico": monitor_request,
+        "analista_activos": analista_request,
+        "asistente_aportacion_mensual": asistente_request,
+    }
+    agent_contexts = {
+        "monitor_tematico": _serialize_agent_context(monitor_context),
+        "analista_activos": _serialize_agent_context(analista_context),
+        "asistente_aportacion_mensual": _serialize_agent_context(asistente_context),
+    }
+    provider_configs = {
+        "monitor_tematico": {
+            "llm": provider_audit_config(monitor_llm_provider, role="llm"),
+            "search": provider_audit_config(monitor_search_provider, role="search"),
+        },
+        "analista_activos": {
+            "llm": provider_audit_config(analista_llm_provider, role="llm"),
+        },
+        "asistente_aportacion_mensual": {
+            "llm": provider_audit_config(asistente_llm_provider, role="llm"),
+        },
+    }
+    raw_responses = {
+        "monitor_tematico": providers_raw_response_audit(
+            {
+                "llm": monitor_llm_provider,
+                "search": monitor_search_provider,
+            }
+        ),
+        "analista_activos": providers_raw_response_audit({"llm": analista_llm_provider}),
+        "asistente_aportacion_mensual": providers_raw_response_audit(
+            {"llm": asistente_llm_provider}
+        ),
+    }
 
     resolved_output_dir = None
     result = MonthlyAgentPipelineResult(
@@ -170,6 +244,11 @@ def run_monthly_agent_pipeline(
         analista_activos=analista_result,
         asistente_aportacion_mensual=asistente_result,
         output_dir=None,
+        agent_requests=agent_requests,
+        agent_contexts=agent_contexts,
+        prompt_audits=prompt_audits,
+        provider_configs=provider_configs,
+        raw_responses=raw_responses,
     )
     if persist:
         resolved_output_dir = _persist_pipeline_result(
@@ -179,6 +258,17 @@ def run_monthly_agent_pipeline(
         )
         result = replace(result, output_dir=resolved_output_dir)
     return result
+
+
+def _request_for_context(request: AgentRequest, context: AgentContext) -> AgentRequest:
+    """Bind one request to the exact input references available to the agent."""
+    return AgentRequest(
+        scope=dict(request.scope),
+        parameters=dict(request.parameters),
+        constraints=dict(request.constraints),
+        input_refs=context.available_input_keys,
+        metadata=dict(request.metadata),
+    )
 
 
 def build_portfolio_metrics_snapshot(metrics: PortfolioMetricsResult, *, as_of_date: date) -> dict[str, Any]:
@@ -365,7 +455,10 @@ def _build_common_input_refs(
             location="derived://portfolio_metrics_snapshot",
             source_type="derived",
             as_of_date=monthly_report_date,
-            metadata={**metrics_snapshot, "content": json.dumps(metrics_snapshot, ensure_ascii=False)},
+            metadata={
+                **metrics_snapshot,
+                "content": _canonical_json_text(metrics_snapshot),
+            },
         ),
     ]
     if user_satellite_interest:
@@ -390,7 +483,7 @@ def _build_common_input_refs(
                     "weights": portfolio_targets.target_weights(),
                     "target_weights": portfolio_targets.target_weights(),
                     "portfolio_targets": payload,
-                    "content": json.dumps(payload, ensure_ascii=False),
+                    "content": _canonical_json_text(payload),
                 },
             )
         )
@@ -406,7 +499,7 @@ def _result_input_ref(key: str, label: str, result: AgentResult) -> AgentInputRe
         source_type="derived",
         metadata={
             "findings": result.findings,
-            "content": json.dumps(payload, ensure_ascii=False),
+            "content": _canonical_json_text(payload),
             "summary": result.summary,
             "status": result.status,
         },
@@ -461,11 +554,36 @@ def _persist_pipeline_result(
         else settings.data_dir / "agents" / "monthly_pipeline" / result.run_id
     )
     base_dir.mkdir(parents=True, exist_ok=True)
-    (base_dir / "pipeline_result.json").write_text(
-        json.dumps(_serialize_pipeline_result(result), ensure_ascii=False, indent=2),
-        encoding="utf-8",
+    agent_payloads = _build_agent_audit_payloads(result, settings=settings)
+    input_hash = _stable_hash(
+        {
+            name: payload["audit_metadata"]["input_hash"]
+            for name, payload in sorted(agent_payloads.items())
+        }
     )
-    _persist_pipeline_audit_trail(result, settings=settings, base_dir=base_dir)
+    output_hash = _stable_hash(
+        {
+            name: payload["audit_metadata"]["output_hash"]
+            for name, payload in sorted(agent_payloads.items())
+        }
+    )
+    _write_json(
+        base_dir / "pipeline_result.json",
+        {
+            "schema_version": AUDIT_SCHEMA_VERSION,
+            "input_hash": input_hash,
+            "output_hash": output_hash,
+            **_serialize_pipeline_result(result),
+        },
+    )
+    _persist_pipeline_audit_trail(
+        result,
+        settings=settings,
+        base_dir=base_dir,
+        agent_payloads=agent_payloads,
+        input_hash=input_hash,
+        output_hash=output_hash,
+    )
     return base_dir
 
 
@@ -474,34 +592,170 @@ def _persist_pipeline_audit_trail(
     *,
     settings: Settings,
     base_dir: Path,
+    agent_payloads: Mapping[str, Mapping[str, Any]],
+    input_hash: str,
+    output_hash: str,
 ) -> None:
-    request = AgentRequest()
     generated_at = _audit_generated_at(result)
     run_metadata = {
+        "schema_version": AUDIT_SCHEMA_VERSION,
         "run_id": result.run_id,
         "as_of_date": result.as_of_date.isoformat(),
         "generated_at": generated_at,
         "base_currency": settings.default_currency,
         "output_dir": str(base_dir),
         "pipeline_result_path": str(base_dir / "pipeline_result.json"),
+        "hash_algorithm": "sha256",
+        "input_hash": input_hash,
+        "output_hash": output_hash,
         "agents": {
-            "monitor_tematico": {"status": result.monitor_tematico.status},
-            "analista_activos": {"status": result.analista_activos.status},
-            "asistente_aportacion_mensual": {"status": result.asistente_aportacion_mensual.status},
+            agent_name: {
+                "status": payload["parsed_output"]["status"],
+                "input_hash": payload["audit_metadata"]["input_hash"],
+                "output_hash": payload["audit_metadata"]["output_hash"],
+                "providers": payload["provider"]["providers"],
+            }
+            for agent_name, payload in agent_payloads.items()
         },
-        "prompt_versions": _agent_prompt_versions(),
+        "prompt_versions": {
+            agent_name: {
+                str(prompt["key"]): str(prompt["version"])
+                for prompt in payload["prompt_refs"].get("prompts", [])
+            }
+            for agent_name, payload in agent_payloads.items()
+        },
     }
     _write_json(base_dir / "run_metadata.json", run_metadata)
     _write_json(
         base_dir / "input_payload.json",
         {
+            "schema_version": AUDIT_SCHEMA_VERSION,
             "run_id": result.run_id,
             "as_of_date": result.as_of_date.isoformat(),
+            "input_hash": input_hash,
             "inputs": [_serialize_input_ref_full(input_ref) for input_ref in result.input_refs],
         },
     )
 
-    agent_specs = (
+    for agent_name, payload in agent_payloads.items():
+        agent_dir = base_dir / "agents" / agent_name
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        _write_json(agent_dir / "context.json", payload["context"])
+        _write_json(agent_dir / "request.json", payload["request"])
+        _write_json(agent_dir / "prompt_refs.json", payload["prompt_refs"])
+        _write_text(agent_dir / "prompt_rendered.md", str(payload["prompt_rendered"]))
+        _write_json(agent_dir / "provider.json", payload["provider"])
+        _write_json(agent_dir / "raw_response.json", payload["raw_response"])
+        _write_json(agent_dir / "parsed_output.json", payload["parsed_output"])
+        _write_json(agent_dir / "audit_metadata.json", payload["audit_metadata"])
+
+
+def _build_agent_audit_payloads(
+    result: MonthlyAgentPipelineResult,
+    *,
+    settings: Settings,
+) -> dict[str, dict[str, Any]]:
+    payloads: dict[str, dict[str, Any]] = {}
+    for agent_name, agent_result, input_refs, context_metadata in _agent_audit_specs(result):
+        context_snapshot = result.agent_contexts.get(agent_name)
+        context_payload = (
+            _json_ready(dict(context_snapshot))
+            if context_snapshot is not None
+            else {
+                "schema_version": AUDIT_SCHEMA_VERSION,
+                "agent_name": agent_name,
+                "run_id": result.run_id,
+                "as_of_date": result.as_of_date.isoformat(),
+                "generated_at": _audit_generated_at(result),
+                "base_currency": settings.default_currency,
+                "input_refs": [_serialize_input_ref_full(input_ref) for input_ref in input_refs],
+                "metadata": _json_ready(context_metadata),
+            }
+        )
+        context_payload = redact_sensitive_audit_payload(context_payload)
+        request = result.agent_requests.get(agent_name) or AgentRequest(
+            input_refs=tuple(input_ref.key for input_ref in input_refs)
+        )
+        # request.json intentionally stays a pure AgentRequest payload for round-trips.
+        request_payload = redact_sensitive_audit_payload(
+            _serialize_agent_request(request)
+        )
+        prompt_snapshot = result.prompt_audits.get(agent_name) or {}
+        prompt_refs = redact_sensitive_audit_payload(
+            dict(
+                prompt_snapshot.get("prompt_refs")
+                or {
+                    "schema_version": AUDIT_SCHEMA_VERSION,
+                    **_agent_prompt_refs(agent_name),
+                }
+            )
+        )
+        prompt_rendered = str(
+            prompt_snapshot.get("prompt_rendered") or _agent_prompt_markdown(agent_name)
+        )
+        provider_payload = redact_sensitive_audit_payload(
+            {
+                "schema_version": AUDIT_SCHEMA_VERSION,
+                "providers": _json_ready(
+                    dict(result.provider_configs.get(agent_name) or {})
+                ),
+            }
+        )
+        raw_response = redact_sensitive_audit_payload(
+            dict(
+                result.raw_responses.get(agent_name)
+                or {
+                    "schema_version": AUDIT_SCHEMA_VERSION,
+                    "status": "not_captured",
+                    "reason_code": "provider_contract_no_raw_response",
+                    "providers": {},
+                    "responses": [],
+                }
+            )
+        )
+        parsed_output = redact_sensitive_audit_payload(
+            {
+                "schema_version": AUDIT_SCHEMA_VERSION,
+                **_serialize_agent_result(agent_result),
+            }
+        )
+        audit_metadata = {
+            "schema_version": AUDIT_SCHEMA_VERSION,
+            "hash_algorithm": "sha256",
+            "hash_projection": "semantic-v1",
+            "input_hash": _stable_hash(
+                {
+                    "context": _context_payload_for_hash(context_payload),
+                    "request": _semantic_hash_payload(
+                        request_payload,
+                        excluded_keys=frozenset(
+                            {"run_id", "generated_at", "retrieved_at"}
+                        ),
+                    ),
+                    "prompt_refs": prompt_refs,
+                    "prompt_rendered": prompt_rendered,
+                    "provider": provider_payload,
+                }
+            ),
+            "output_hash": _stable_hash(_output_payload_for_hash(parsed_output)),
+        }
+        payloads[agent_name] = {
+            "context": context_payload,
+            "request": request_payload,
+            "prompt_refs": prompt_refs,
+            "prompt_rendered": prompt_rendered,
+            "provider": provider_payload,
+            "raw_response": raw_response,
+            "parsed_output": parsed_output,
+            "audit_metadata": audit_metadata,
+        }
+    return payloads
+
+
+def _agent_audit_specs(
+    result: MonthlyAgentPipelineResult,
+) -> tuple[tuple[str, AgentResult, tuple[AgentInputRef, ...], Mapping[str, Any]], ...]:
+    return (
         (
             "monitor_tematico",
             result.monitor_tematico,
@@ -511,7 +765,14 @@ def _persist_pipeline_audit_trail(
         (
             "analista_activos",
             result.analista_activos,
-            (*result.input_refs, _result_input_ref("monitor_tematico_result", "Monitor tematico result", result.monitor_tematico)),
+            (
+                *result.input_refs,
+                _result_input_ref(
+                    "monitor_tematico_result",
+                    "Monitor tematico result",
+                    result.monitor_tematico,
+                ),
+            ),
             {},
         ),
         (
@@ -519,53 +780,93 @@ def _persist_pipeline_audit_trail(
             result.asistente_aportacion_mensual,
             (
                 *result.input_refs,
-                _result_input_ref("monitor_tematico_result", "Monitor tematico result", result.monitor_tematico),
-                _result_input_ref("analista_activos_result", "Analista activos result", result.analista_activos),
+                _result_input_ref(
+                    "monitor_tematico_result",
+                    "Monitor tematico result",
+                    result.monitor_tematico,
+                ),
+                _result_input_ref(
+                    "analista_activos_result",
+                    "Analista activos result",
+                    result.analista_activos,
+                ),
             ),
             {},
         ),
     )
-    for agent_name, agent_result, input_refs, context_metadata in agent_specs:
-        agent_dir = base_dir / "agents" / agent_name
-        agent_dir.mkdir(parents=True, exist_ok=True)
-        context_payload = {
-            "agent_name": agent_name,
-            "run_id": result.run_id,
-            "as_of_date": result.as_of_date.isoformat(),
-            "generated_at": generated_at,
-            "base_currency": settings.default_currency,
-            "input_refs": [_serialize_input_ref_full(input_ref) for input_ref in input_refs],
-            "metadata": _json_ready(context_metadata),
-        }
-        _write_json(agent_dir / "context.json", context_payload)
-        _write_json(agent_dir / "request.json", _serialize_agent_request(request))
-        _write_json(agent_dir / "prompt_refs.json", _agent_prompt_refs(agent_name))
-        (agent_dir / "prompt_rendered.md").write_text(_agent_prompt_markdown(agent_name), encoding="utf-8")
-        _write_json(
-            agent_dir / "raw_response.json",
-            {
-                "status": "not_captured",
-                "reason": (
-                    "Current agent providers return parsed domain objects. Raw provider responses "
-                    "are not exposed by the provider contract yet."
-                ),
-            },
-        )
-        _write_json(agent_dir / "parsed_output.json", _serialize_agent_result(agent_result))
+
+
+def _serialize_agent_context(context: AgentContext) -> dict[str, Any]:
+    return {
+        "schema_version": AUDIT_SCHEMA_VERSION,
+        "agent_name": context.agent_name,
+        "run_id": context.run_id,
+        "as_of_date": context.as_of_date.isoformat(),
+        "generated_at": context.generated_at.isoformat(),
+        "base_currency": context.base_currency,
+        "input_refs": [_serialize_input_ref_full(input_ref) for input_ref in context.input_refs],
+        "metadata": _json_ready(dict(context.metadata)),
+    }
+
+
+def _context_payload_for_hash(context_payload: Mapping[str, Any]) -> dict[str, Any]:
+    return _semantic_hash_payload(
+        context_payload,
+        excluded_keys=frozenset({"run_id", "generated_at", "retrieved_at"}),
+    )
+
+
+def _output_payload_for_hash(output_payload: Mapping[str, Any]) -> dict[str, Any]:
+    return _semantic_hash_payload(
+        output_payload,
+        excluded_keys=frozenset({"run_id", "generated_at", "retrieved_at"}),
+    )
+
+
+def _semantic_hash_payload(
+    value: Any,
+    *,
+    excluded_keys: frozenset[str],
+) -> Any:
+    """Remove runtime-only data while preserving semantic content for hashing."""
+    ready = _json_ready(value)
+    if isinstance(ready, Mapping):
+        projected: dict[str, Any] = {}
+        for key, item in ready.items():
+            key_str = str(key)
+            if key_str in excluded_keys:
+                continue
+            if key_str in {"location", "path"} and _looks_like_local_path(item):
+                projected[key_str] = "<local-path>"
+            else:
+                projected[key_str] = _semantic_hash_payload(
+                    item,
+                    excluded_keys=excluded_keys,
+                )
+        return projected
+    if isinstance(ready, list):
+        return [
+            _semantic_hash_payload(item, excluded_keys=excluded_keys)
+            for item in ready
+        ]
+    return ready
+
+
+def _looks_like_local_path(value: Any) -> bool:
+    if not isinstance(value, str) or "://" in value:
+        return False
+    return bool(re.match(r"^[A-Za-z]:[\\/]", value)) or Path(value).is_absolute()
 
 
 def _audit_generated_at(result: MonthlyAgentPipelineResult) -> str | None:
+    for context in result.agent_contexts.values():
+        generated_at = context.get("generated_at")
+        if generated_at:
+            return str(generated_at)
     for input_ref in result.input_refs:
         if input_ref.generated_at is not None:
             return input_ref.generated_at.isoformat()
     return None
-
-
-def _agent_prompt_versions() -> dict[str, dict[str, str]]:
-    return {
-        agent_name: {key: prompt_version(key) for key in prompt_keys}
-        for agent_name, prompt_keys in _agent_prompt_keys().items()
-    }
 
 
 def _agent_prompt_refs(agent_name: str) -> dict[str, Any]:
@@ -621,7 +922,39 @@ def _serialize_agent_request(request: AgentRequest) -> dict[str, Any]:
 
 
 def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
-    path.write_text(json.dumps(_json_ready(dict(payload)), ensure_ascii=False, indent=2), encoding="utf-8")
+    safe_payload = redact_sensitive_audit_payload(
+        _json_ready(dict(payload))
+    )
+    _write_text(
+        path,
+        json.dumps(
+            safe_payload,
+            ensure_ascii=False,
+            indent=2,
+            allow_nan=False,
+        ),
+    )
+
+
+def _write_text(path: Path, content: str) -> None:
+    temp_path = path.with_name(f".{path.name}.tmp")
+    temp_path.write_text(content, encoding="utf-8")
+    temp_path.replace(path)
+
+
+def _stable_hash(payload: Any) -> str:
+    canonical = _canonical_json_text(payload)
+    return f"sha256:{hashlib.sha256(canonical.encode('utf-8')).hexdigest()}"
+
+
+def _canonical_json_text(payload: Any) -> str:
+    return json.dumps(
+        redact_sensitive_audit_payload(_json_ready(payload)),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
 
 
 def _serialize_pipeline_result(result: MonthlyAgentPipelineResult) -> dict[str, Any]:
@@ -662,13 +995,17 @@ def _serialize_agent_result(result: AgentResult) -> dict[str, Any]:
 
 
 def _serialize_agent_result_for_input_ref(result: AgentResult) -> dict[str, Any]:
-    return {
-        "status": result.status,
-        "summary": result.summary,
-        "warnings": list(result.warnings),
-        "errors": list(result.errors),
-        "findings": [_serialize_finding(finding) for finding in result.findings],
-    }
+    # Downstream agents receive semantic output, not retrieval timestamps or local paths.
+    return _semantic_hash_payload(
+        {
+            "status": result.status,
+            "summary": result.summary,
+            "warnings": list(result.warnings),
+            "errors": list(result.errors),
+            "findings": [_serialize_finding(finding) for finding in result.findings],
+        },
+        excluded_keys=frozenset({"run_id", "generated_at", "retrieved_at"}),
+    )
 
 
 def _serialize_finding(finding) -> dict[str, Any]:
@@ -753,7 +1090,7 @@ def _apply_asset_overrides_to_metrics_snapshot(
                 position["asset_type"] = override_type
         positions.append(position)
     updated["positions"] = _json_ready(positions)
-    updated["content"] = json.dumps(updated, ensure_ascii=False)
+    updated["content"] = _canonical_json_text(updated)
     return updated
 
 
@@ -822,10 +1159,22 @@ def _json_ready(value: Any) -> Any:
         return {str(key): _json_ready(item) for key, item in value.items()}
     if isinstance(value, (tuple, list)):
         return [_json_ready(item) for item in value]
+    if isinstance(value, (set, frozenset)):
+        return [_json_ready(item) for item in sorted(value, key=str)]
     if isinstance(value, (datetime, date)):
         return value.isoformat()
     if isinstance(value, pd.Timestamp):
         return value.isoformat()
-    if pd.isna(value):
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, float) and not isfinite(value):
         return None
+    try:
+        if value is None or bool(pd.isna(value)):
+            return None
+    except (TypeError, ValueError):
+        pass
+    item = getattr(value, "item", None)
+    if callable(item):
+        return _json_ready(item())
     return value

--- a/src/agents/prompts/README.md
+++ b/src/agents/prompts/README.md
@@ -22,6 +22,16 @@ Prompts actuales:
 - `asistente_aportacion_mensual_decision_v1.md`: decision mensual.
 
 En los runs persistidos, `prompt_refs.json` registra claves/versiones y
-`prompt_rendered.md` conserva el texto cargado. `raw_response.json` permanece
-con estado `not_captured` porque los providers devuelven objetos de dominio ya
-parseados.
+`prompt_rendered.md` conserva el texto cargado. Ambos forman parte del
+`input_hash` semantico del agente: cambiar una version o el texto renderizado
+debe cambiar la huella aunque el resto de inputs sea igual.
+
+`raw_response.json` es un artefacto distinto del prompt. En el schema de
+auditoria v2 usa `captured`, `partial` o `not_captured` segun lo que exponga el
+contrato del provider, y conserva un `reason_code` estable cuando la captura no
+es completa. Los providers deterministas normalmente usan `not_captured`
+porque no existe una respuesta bruta de SDK separada de su salida de dominio.
+
+Los prompts renderizados y respuestas raw pueden contener contexto privado de
+la cartera. Permanecen en el directorio local ignorado por Git y no deben
+publicarse salvo que procedan de la demo sintetica y se hayan revisado.

--- a/src/agents/provider_audit.py
+++ b/src/agents/provider_audit.py
@@ -1,0 +1,299 @@
+"""Safe, provider-agnostic metadata used by agent audit trails."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, is_dataclass
+from datetime import date, datetime
+import json
+from math import isfinite
+from pathlib import Path
+import re
+from typing import Any, Mapping
+from urllib.parse import urlsplit, urlunsplit
+
+
+_RAW_RESPONSES_ATTRIBUTE = "_ml_finance_audit_raw_responses"
+_FAILURES_ATTRIBUTE = "_ml_finance_audit_provider_failures"
+_SENSITIVE_KEYS = frozenset(
+    {
+        "api_key",
+        "authorization",
+        "proxy_authorization",
+        "bearer_token",
+        "access_token",
+        "refresh_token",
+        "token",
+        "client_secret",
+        "private_key",
+        "secret",
+        "password",
+        "cookie",
+        "set_cookie",
+        "headers",
+        "request_headers",
+        "response_headers",
+    }
+)
+
+
+def provider_audit_config(provider: Any, *, role: str) -> dict[str, Any]:
+    """Return an allowlisted provider configuration without credentials."""
+    name = str(getattr(provider, "name", type(provider).__name__))
+    model = getattr(provider, "model", None)
+    options: dict[str, Any] = {}
+    for attribute in ("timeout_seconds", "search_depth", "endpoint"):
+        value = getattr(provider, attribute, None)
+        if value is not None:
+            options[attribute] = (
+                _sanitize_endpoint(value)
+                if attribute == "endpoint"
+                else _json_safe(value)
+            )
+    if name == "openai":
+        options["response_format"] = "json_schema"
+    elif name in {"static", "static_llm", "null"}:
+        options["mode"] = "deterministic_offline"
+    return {
+        "role": role,
+        "provider": name,
+        "model": str(model) if model is not None else None,
+        "options": options,
+    }
+
+
+def record_provider_raw_response(provider: Any, response: Any, *, operation: str) -> None:
+    """Capture one response already returned by a provider SDK."""
+    try:
+        response_payload = _provider_response_payload(response)
+        # Validate now so audit serialization can never break a successful agent call.
+        json.dumps(response_payload, allow_nan=False)
+    except Exception:
+        record_provider_failure(
+            provider,
+            operation=operation,
+            reason_code="raw_response_serialization_failed",
+        )
+        return
+    try:
+        records = getattr(provider, _RAW_RESPONSES_ATTRIBUTE, None)
+        if records is None:
+            records = []
+            setattr(provider, _RAW_RESPONSES_ATTRIBUTE, records)
+        records.append(
+            {
+                "operation": operation,
+                "response": response_payload,
+            }
+        )
+    except Exception:
+        record_provider_failure(
+            provider,
+            operation=operation,
+            reason_code="raw_response_storage_failed",
+        )
+
+
+def record_provider_failure(
+    provider: Any,
+    *,
+    operation: str,
+    reason_code: str = "provider_request_failed_before_response",
+) -> None:
+    """Record a failure reason without persisting exception text or credentials."""
+    try:
+        failures = getattr(provider, _FAILURES_ATTRIBUTE, None)
+        if failures is None:
+            failures = []
+            setattr(provider, _FAILURES_ATTRIBUTE, failures)
+        failures.append({"operation": operation, "reason_code": reason_code})
+    except Exception:
+        # Audit is best-effort and must never replace the provider's real outcome.
+        return
+
+
+def provider_raw_response_audit(provider: Any, *, role: str) -> dict[str, Any]:
+    """Return captured responses or a stable reason for their absence."""
+    config = provider_audit_config(provider, role=role)
+    records = list(getattr(provider, _RAW_RESPONSES_ATTRIBUTE, ()) or ())
+    failures = list(getattr(provider, _FAILURES_ATTRIBUTE, ()) or ())
+    if records:
+        return {
+            "schema_version": 2,
+            "status": "partial" if failures else "captured",
+            "reason_code": (
+                "one_or_more_provider_responses_not_captured"
+                if failures
+                else None
+            ),
+            "provider": config,
+            "responses": _json_safe(records),
+            "failures": _json_safe(failures),
+        }
+    if failures:
+        reason_code = str(failures[-1]["reason_code"])
+    elif config["provider"] in {"static", "static_llm", "null"}:
+        reason_code = "deterministic_provider_no_raw_response"
+    elif role == "search":
+        reason_code = "provider_contract_returns_normalized_results"
+    else:
+        reason_code = "provider_contract_no_raw_response"
+    return {
+        "schema_version": 2,
+        "status": "not_captured",
+        "reason_code": reason_code,
+        "provider": config,
+        "responses": [],
+        "failures": _json_safe(failures),
+    }
+
+
+def providers_raw_response_audit(providers: Mapping[str, Any]) -> dict[str, Any]:
+    """Aggregate raw-response status for every provider role used by one agent."""
+    audits = {
+        role: provider_raw_response_audit(provider, role=role)
+        for role, provider in providers.items()
+    }
+    statuses = [str(audit["status"]) for audit in audits.values()]
+    captured_count = statuses.count("captured")
+    if statuses and captured_count == len(statuses):
+        status = "captured"
+        reason_code = None
+    elif any(audit.get("responses") for audit in audits.values()):
+        status = "partial"
+        reason_code = "one_or_more_provider_responses_not_captured"
+    else:
+        status = "not_captured"
+        reasons = {
+            str(audit.get("reason_code"))
+            for audit in audits.values()
+            if audit.get("reason_code")
+        }
+        reason_code = (
+            next(iter(reasons))
+            if len(reasons) == 1
+            else "provider_responses_not_captured"
+        )
+    responses = [
+        {"role": role, **dict(response)}
+        for role, audit in audits.items()
+        for response in audit.get("responses", [])
+    ]
+    return {
+        "schema_version": 2,
+        "status": status,
+        "reason_code": reason_code,
+        "providers": audits,
+        "responses": _json_safe(responses),
+    }
+
+
+def _provider_response_payload(response: Any) -> Any:
+    model_dump = getattr(response, "model_dump", None)
+    if callable(model_dump):
+        try:
+            return _json_safe(model_dump(mode="json"))
+        except TypeError:
+            return _json_safe(model_dump())
+    to_dict = getattr(response, "to_dict", None)
+    if callable(to_dict):
+        return _json_safe(to_dict())
+
+    payload = {}
+    for attribute in ("id", "model", "created_at", "status", "output_text", "usage", "error"):
+        value = getattr(response, attribute, None)
+        if value is not None:
+            payload[attribute] = _json_safe(value)
+    return payload
+
+
+def _json_safe(value: Any) -> Any:
+    if is_dataclass(value):
+        return _json_safe(asdict(value))
+    if isinstance(value, Mapping):
+        return {
+            str(key): (
+                "[REDACTED]"
+                if _is_sensitive_key(str(key))
+                else _json_safe(item)
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, (tuple, list)):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, float) and not isfinite(value):
+        return None
+    item = getattr(value, "item", None)
+    if callable(item):
+        return _json_safe(item())
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        return _json_safe(model_dump(mode="json"))
+    return value
+
+
+def redact_sensitive_audit_payload(value: Any) -> Any:
+    """Return a JSON-safe copy with credential-shaped keys redacted."""
+    return _json_safe(value)
+
+
+def _is_sensitive_key(key: str) -> bool:
+    normalized = re.sub(r"[^a-z0-9]+", "_", key.strip().lower()).strip("_")
+    compact = normalized.replace("_", "")
+    return (
+        normalized in _SENSITIVE_KEYS
+        or compact
+        in {
+            "apikey",
+            "authorization",
+            "proxyauthorization",
+            "bearertoken",
+            "accesstoken",
+            "refreshtoken",
+            "clientsecret",
+            "privatekey",
+            "password",
+            "setcookie",
+            "headers",
+            "requestheaders",
+            "responseheaders",
+        }
+        or normalized.endswith("_api_key")
+        or normalized.endswith("_access_token")
+        or normalized.endswith("_refresh_token")
+        or normalized.endswith("_token")
+        or normalized.endswith("_authorization")
+        or normalized.endswith("_password")
+        or normalized.endswith("_private_key")
+        or normalized.endswith("_secret")
+    )
+
+
+def _sanitize_endpoint(value: Any) -> str:
+    endpoint = str(value)
+    parsed = urlsplit(endpoint)
+    if not parsed.scheme or not parsed.netloc:
+        sanitized = endpoint.split("?", maxsplit=1)[0].split("#", maxsplit=1)[0]
+        return sanitized.rsplit("@", maxsplit=1)[-1]
+    hostname = parsed.hostname or ""
+    if ":" in hostname and not hostname.startswith("["):
+        hostname = f"[{hostname}]"
+    try:
+        port = parsed.port
+    except ValueError:
+        port = None
+    netloc = f"{hostname}:{port}" if port is not None else hostname
+    return urlunsplit((parsed.scheme, netloc, parsed.path, "", ""))
+
+
+__all__ = [
+    "provider_audit_config",
+    "provider_raw_response_audit",
+    "providers_raw_response_audit",
+    "redact_sensitive_audit_payload",
+    "record_provider_failure",
+    "record_provider_raw_response",
+]

--- a/src/application/README.md
+++ b/src/application/README.md
@@ -61,6 +61,18 @@ auditoria persistida en disco. Streamlit los usa para visualizar plan interno,
 acciones, fuentes, prompts, warnings, inputs y outputs sin acoplar la UI a la
 estructura fisica de carpetas.
 
+El read model de auditoria expone tambien la metadata reproducible del schema
+v2: request y contexto efectivos, provider/modelo/opciones no secretas,
+respuesta raw con estado y `reason_code`, y hashes SHA-256 de entrada/salida.
+La lectura es compatible con runs legacy v1: los archivos o campos que todavia
+no existian se devuelven como no disponibles y nunca se escriben durante una
+consulta.
+
+La capa de aplicacion no debe exponer credenciales al adaptar esta metadata para
+Streamlit o una futura API. La configuracion de provider procede de una lista
+permitida y los artefactos completos siguen siendo privados aunque contengan
+solo hashes o providers offline.
+
 `RunMonitorTematicoUseCase` ofrece el mismo limite para ejecuciones aisladas del
 monitor. Sus defaults `static/null` no usan red.
 

--- a/src/application/agent_audit.py
+++ b/src/application/agent_audit.py
@@ -7,6 +7,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+from src.agents.provider_audit import redact_sensitive_audit_payload
 from src.config import Settings, get_settings
 
 
@@ -41,6 +42,9 @@ class GetAgentRunAuditResult:
     input_payload: dict[str, Any]
     agents: dict[str, dict[str, Any]]
     preflight: dict[str, Any] = field(default_factory=dict)
+    schema_version: int = 1
+    is_legacy: bool = True
+    compatibility_warnings: tuple[str, ...] = ()
 
 
 class ListAgentRunsUseCase:
@@ -80,9 +84,16 @@ class GetAgentRunAuditUseCase:
         if not output_dir.exists():
             raise FileNotFoundError(f"Agent run not found: {run_id}")
 
-        run_metadata = _read_json_or_empty(output_dir / "run_metadata.json")
-        input_payload = _read_json_or_empty(output_dir / "input_payload.json")
-        preflight = _read_json_or_empty(output_dir / "preflight.json")
+        run_metadata = redact_sensitive_audit_payload(
+            _read_json_or_empty(output_dir / "run_metadata.json")
+        )
+        input_payload = redact_sensitive_audit_payload(
+            _read_json_or_empty(output_dir / "input_payload.json")
+        )
+        preflight = redact_sensitive_audit_payload(
+            _read_json_or_empty(output_dir / "preflight.json")
+        )
+        schema_version, compatibility_warnings = _audit_schema_compatibility(run_metadata)
         agents = {
             agent_name: _read_agent_audit(output_dir / "agents" / agent_name)
             for agent_name in AGENT_NAMES
@@ -94,6 +105,9 @@ class GetAgentRunAuditUseCase:
             input_payload=input_payload,
             preflight=preflight,
             agents=agents,
+            schema_version=schema_version,
+            is_legacy=schema_version < 2,
+            compatibility_warnings=compatibility_warnings,
         )
 
 
@@ -173,14 +187,38 @@ def _safe_run_id(value: str) -> str:
 
 
 def _read_agent_audit(agent_dir: Path) -> dict[str, Any]:
-    return {
-        "context": _read_json_or_empty(agent_dir / "context.json"),
-        "request": _read_json_or_empty(agent_dir / "request.json"),
-        "prompt_refs": _read_json_or_empty(agent_dir / "prompt_refs.json"),
-        "prompt_rendered": _read_text_or_empty(agent_dir / "prompt_rendered.md"),
-        "raw_response": _read_json_or_empty(agent_dir / "raw_response.json"),
-        "parsed_output": _read_json_or_empty(agent_dir / "parsed_output.json"),
-    }
+    # Redact every JSON artifact in case a legacy/manually edited run contains credentials.
+    return redact_sensitive_audit_payload(
+        {
+            "context": _read_json_or_empty(agent_dir / "context.json"),
+            "request": _read_json_or_empty(agent_dir / "request.json"),
+            "prompt_refs": _read_json_or_empty(agent_dir / "prompt_refs.json"),
+            "prompt_rendered": _read_text_or_empty(agent_dir / "prompt_rendered.md"),
+            "provider": _read_json_or_empty(agent_dir / "provider.json"),
+            "raw_response": _read_json_or_empty(agent_dir / "raw_response.json"),
+            "parsed_output": _read_json_or_empty(agent_dir / "parsed_output.json"),
+            "audit_metadata": _read_json_or_empty(agent_dir / "audit_metadata.json"),
+        }
+    )
+
+
+def _audit_schema_compatibility(
+    run_metadata: dict[str, Any],
+) -> tuple[int, tuple[str, ...]]:
+    raw_version = run_metadata.get("schema_version", 1)
+    try:
+        schema_version = int(raw_version)
+    except (TypeError, ValueError):
+        return 1, (f"Invalid audit schema_version: {raw_version!r}; read as legacy v1.",)
+    if schema_version < 2:
+        return schema_version, (
+            "Legacy audit: provider metadata and reproducibility hashes may be unavailable.",
+        )
+    if schema_version > 2:
+        return schema_version, (
+            f"Audit schema v{schema_version} is newer than supported v2; showing raw compatible fields.",
+        )
+    return schema_version, ()
 
 
 def _summary_from_metadata(metadata: dict[str, Any], *, run_dir: Path) -> AgentRunSummary:

--- a/src/application/agents.py
+++ b/src/application/agents.py
@@ -32,7 +32,10 @@ class RunMonthlyAgentsRequest:
     search_provider: str = "null"
     persist: bool = True
     output_dir: Path | None = None
+    request_scope: Mapping[str, Any] | None = None
     request_parameters: Mapping[str, Any] | None = None
+    request_constraints: Mapping[str, Any] | None = None
+    request_metadata: Mapping[str, Any] | None = None
     portfolio_metrics_snapshot: Mapping[str, Any] | None = None
     monthly_budget: float | None = None
 
@@ -89,7 +92,10 @@ class RunMonthlyAgentsUseCase:
             search_provider=resolved_request.search_provider,
             persist=resolved_request.persist,
             output_dir=resolved_request.output_dir,
+            request_scope=resolved_request.request_scope,
             request_parameters=resolved_request.request_parameters,
+            request_constraints=resolved_request.request_constraints,
+            request_metadata=resolved_request.request_metadata,
             portfolio_metrics_snapshot=resolved_request.portfolio_metrics_snapshot,
             monthly_budget=resolved_request.monthly_budget,
         )

--- a/src/portfolio/dashboard_agents.py
+++ b/src/portfolio/dashboard_agents.py
@@ -230,7 +230,14 @@ def _render_persisted_agent_audit(settings: Settings) -> None:
         st.error(str(exc))
         return
 
-    _render_run_overview(audit.run_metadata, audit.input_payload, audit.preflight, audit.output_dir)
+    _render_run_overview(
+        audit.run_metadata,
+        audit.input_payload,
+        audit.preflight,
+        audit.output_dir,
+        schema_version=audit.schema_version,
+        compatibility_warnings=audit.compatibility_warnings,
+    )
     if audit.run_metadata.get("execution_status") == "blocked":
         st.info("Los agentes no se ejecutaron porque el preflight detecto errores bloqueantes.")
         return
@@ -249,6 +256,9 @@ def _render_run_overview(
     input_payload: Mapping[str, Any],
     preflight: Mapping[str, Any],
     output_dir: Path,
+    *,
+    schema_version: int,
+    compatibility_warnings: tuple[str, ...],
 ) -> None:
     st.markdown("#### Run")
     columns = st.columns(4)
@@ -269,6 +279,18 @@ def _render_run_overview(
         _render_input_refs(input_payload.get("inputs") or [], key_prefix="run")
     with st.expander("Prompt versions", expanded=False):
         st.json(run_metadata.get("prompt_versions") or {})
+    with st.expander("Reproducibilidad", expanded=False):
+        if compatibility_warnings:
+            st.info("\n".join(compatibility_warnings))
+        if schema_version >= 2:
+            st.json(
+                {
+                    "schema_version": schema_version,
+                    "hash_algorithm": run_metadata.get("hash_algorithm"),
+                    "input_hash": run_metadata.get("input_hash"),
+                    "output_hash": run_metadata.get("output_hash"),
+                }
+            )
     st.caption(f"Directorio local: {output_dir}")
 
 
@@ -279,7 +301,9 @@ def _render_agent_audit(agent_name: str, audit: Mapping[str, Any]) -> None:
     request = audit.get("request") or {}
     prompt_refs = audit.get("prompt_refs") or {}
     prompt_rendered = audit.get("prompt_rendered") or ""
+    provider = audit.get("provider") or {}
     raw_response = audit.get("raw_response") or {}
+    audit_metadata = audit.get("audit_metadata") or {}
 
     status = parsed.get("status") or "sin_datos"
     st.markdown(f"#### {agent_name}: `{status}`")
@@ -289,19 +313,65 @@ def _render_agent_audit(agent_name: str, audit: Mapping[str, Any]) -> None:
     _render_warning_error_blocks(parsed)
     render_agent_autonomy(metadata)
 
-    detail_tabs = st.tabs(["Outputs", "Fuentes", "Prompts", "Inputs", "Request", "Raw"])
-    with detail_tabs[0]:
+    labels = ["Outputs", "Fuentes", "Prompts", "Inputs"]
+    for label, payload in (
+        ("Request", request),
+        ("Provider", provider),
+        ("Raw", raw_response),
+        ("Hashes", audit_metadata),
+    ):
+        if payload:
+            labels.append(label)
+    detail_tabs = dict(zip(labels, st.tabs(labels), strict=True))
+    with detail_tabs["Outputs"]:
         _render_agent_outputs(parsed, metadata)
-    with detail_tabs[1]:
+    with detail_tabs["Fuentes"]:
         _render_sources(parsed)
-    with detail_tabs[2]:
+    with detail_tabs["Prompts"]:
         _render_prompts(prompt_refs, prompt_rendered, key_prefix=agent_name)
-    with detail_tabs[3]:
+    with detail_tabs["Inputs"]:
         _render_input_refs(context.get("input_refs") or [], key_prefix=agent_name)
-    with detail_tabs[4]:
-        st.json(request)
-    with detail_tabs[5]:
-        st.json(raw_response)
+    if "Request" in detail_tabs:
+        with detail_tabs["Request"]:
+            st.json(request)
+    if "Provider" in detail_tabs:
+        with detail_tabs["Provider"]:
+            st.json(provider)
+    if "Raw" in detail_tabs:
+        with detail_tabs["Raw"]:
+            st.warning(
+                "Artefacto privado: puede contener prompts, datos de cartera y salida completa del proveedor."
+            )
+            st.json(_raw_response_summary(raw_response))
+            responses = raw_response.get("responses") or []
+            if responses:
+                with st.expander("Respuestas completas", expanded=False):
+                    st.json(responses)
+    if "Hashes" in detail_tabs:
+        with detail_tabs["Hashes"]:
+            st.json(audit_metadata)
+
+
+def _raw_response_summary(raw_response: Mapping[str, Any]) -> dict[str, Any]:
+    """Hide full response bodies from the default, screenshot-prone view."""
+    summary = {
+        key: value
+        for key, value in raw_response.items()
+        if key != "responses"
+    }
+    providers = raw_response.get("providers")
+    if isinstance(providers, Mapping):
+        summary["providers"] = {
+            role: {
+                key: value
+                for key, value in audit.items()
+                if key != "responses"
+            }
+            if isinstance(audit, Mapping)
+            else audit
+            for role, audit in providers.items()
+        }
+    return summary
 
 
 def _render_warning_error_blocks(parsed: Mapping[str, Any]) -> None:

--- a/tests/test_agent_audit_trail.py
+++ b/tests/test_agent_audit_trail.py
@@ -1,12 +1,21 @@
 from __future__ import annotations
 
-from datetime import date
+from dataclasses import replace
+from datetime import date, datetime, timezone
 import json
 from pathlib import Path
 import shutil
 from uuid import uuid4
 
-from src.agents.models import AgentFinding, AgentInputRef, AgentResult
+import numpy as np
+
+from src.agents.models import (
+    AgentFinding,
+    AgentInputRef,
+    AgentRequest,
+    AgentResult,
+    AgentSource,
+)
 from src.agents.pipeline import MonthlyAgentPipelineResult, _persist_pipeline_result
 from src.application.agent_audit import (
     GetAgentRunAuditRequest,
@@ -38,6 +47,36 @@ def test_persist_pipeline_result_writes_audit_trail_files() -> None:
             monitor_tematico=_agent_result("monitor ok"),
             analista_activos=_agent_result("asset ok"),
             asistente_aportacion_mensual=_agent_result("assistant ok"),
+            agent_requests={
+                agent_name: AgentRequest(
+                    scope={"universe": "portfolio"},
+                    parameters={"max_items": 5},
+                    constraints={"network": "offline"},
+                    input_refs=("investment_brief",),
+                    metadata={"origin": "test"},
+                )
+                for agent_name in (
+                    "monitor_tematico",
+                    "analista_activos",
+                    "asistente_aportacion_mensual",
+                )
+            },
+            provider_configs={
+                "monitor_tematico": {
+                    "llm": {
+                        "role": "llm",
+                        "provider": "static_llm",
+                        "model": None,
+                        "options": {"mode": "deterministic_offline"},
+                    },
+                    "search": {
+                        "role": "search",
+                        "provider": "null",
+                        "model": None,
+                        "options": {"mode": "deterministic_offline"},
+                    },
+                }
+            },
         )
 
         persisted_dir = _persist_pipeline_result(result, settings=settings, output_dir=output_dir)
@@ -57,12 +96,23 @@ def test_persist_pipeline_result_writes_audit_trail_files() -> None:
         assert preflight_path == persisted_dir / "preflight.json"
         run_metadata = _read_json(persisted_dir / "run_metadata.json")
         input_payload = _read_json(persisted_dir / "input_payload.json")
+        pipeline_result = _read_json(persisted_dir / "pipeline_result.json")
 
         assert run_metadata["run_id"] == "run-audit-001"
         assert run_metadata["execution_status"] == "succeeded"
         assert run_metadata["preflight"]["status"] == "passed"
+        assert run_metadata["schema_version"] == 2
+        assert run_metadata["hash_algorithm"] == "sha256"
+        assert run_metadata["input_hash"].startswith("sha256:")
+        assert len(run_metadata["input_hash"]) == 71
+        assert run_metadata["output_hash"].startswith("sha256:")
+        assert len(run_metadata["output_hash"]) == 71
         assert run_metadata["prompt_versions"]["monitor_tematico"]["monitor_tematico.query"] == "v1"
+        assert input_payload["schema_version"] == 2
+        assert input_payload["input_hash"] == run_metadata["input_hash"]
         assert input_payload["inputs"][0]["metadata"]["content"] == "brief text"
+        assert pipeline_result["input_hash"] == run_metadata["input_hash"]
+        assert pipeline_result["output_hash"] == run_metadata["output_hash"]
 
         for agent_name in ("monitor_tematico", "analista_activos", "asistente_aportacion_mensual"):
             agent_dir = persisted_dir / "agents" / agent_name
@@ -70,18 +120,41 @@ def test_persist_pipeline_result_writes_audit_trail_files() -> None:
             assert (agent_dir / "request.json").exists()
             assert (agent_dir / "prompt_refs.json").exists()
             assert (agent_dir / "prompt_rendered.md").exists()
+            assert (agent_dir / "provider.json").exists()
             assert (agent_dir / "raw_response.json").exists()
             assert (agent_dir / "parsed_output.json").exists()
+            assert (agent_dir / "audit_metadata.json").exists()
 
             context = _read_json(agent_dir / "context.json")
+            request = _read_json(agent_dir / "request.json")
+            provider = _read_json(agent_dir / "provider.json")
             raw_response = _read_json(agent_dir / "raw_response.json")
             parsed_output = _read_json(agent_dir / "parsed_output.json")
+            audit_metadata = _read_json(agent_dir / "audit_metadata.json")
 
             assert context["agent_name"] == agent_name
+            assert request["scope"] == {"universe": "portfolio"}
+            assert request["parameters"] == {"max_items": 5}
+            assert request["constraints"] == {"network": "offline"}
+            assert request["input_refs"] == ["investment_brief"]
+            assert "schema_version" not in request
+            restored_request = AgentRequest(
+                scope=request["scope"],
+                parameters=request["parameters"],
+                constraints=request["constraints"],
+                input_refs=tuple(request["input_refs"]),
+                metadata=request["metadata"],
+            )
+            assert restored_request == result.agent_requests[agent_name]
+            assert provider["schema_version"] == 2
             assert raw_response["status"] == "not_captured"
+            assert raw_response["reason_code"] == "provider_contract_no_raw_response"
             assert parsed_output["status"] == "success"
             assert parsed_output["metadata"]["agent_plan"] == ["Plan step"]
             assert parsed_output["metadata"]["selected_actions"] == ["test_action"]
+            assert audit_metadata["hash_projection"] == "semantic-v1"
+            assert audit_metadata["input_hash"].startswith("sha256:")
+            assert audit_metadata["output_hash"].startswith("sha256:")
     finally:
         shutil.rmtree(workspace, ignore_errors=True)
 
@@ -117,6 +190,56 @@ def test_blocked_preflight_attempt_is_auditable_without_agent_outputs() -> None:
         shutil.rmtree(workspace, ignore_errors=True)
 
 
+def test_audit_hashes_are_deterministic_and_change_with_input_content() -> None:
+    workspace = _make_workspace()
+    try:
+        settings = load_settings(repo_root=workspace, env={}, env_file=workspace / ".env.missing")
+        first_dir = _persist_pipeline_result(
+            _pipeline_result(
+                run_id="run-1",
+                input_content="same",
+                input_location=str(workspace / "one" / "brief.md"),
+                extra_metadata={"alpha": 1, "beta": 2},
+                finding_metadata={"alpha": 1, "beta": 2},
+                retrieved_at=datetime(2026, 5, 26, 8, 0, tzinfo=timezone.utc),
+            ),
+            settings=settings,
+            output_dir=workspace / "audit-1",
+        )
+        second_dir = _persist_pipeline_result(
+            _pipeline_result(
+                run_id="run-2",
+                input_content="same",
+                input_location=str(workspace / "two" / "brief.md"),
+                extra_metadata={"beta": 2, "alpha": 1},
+                finding_metadata={"beta": 2, "alpha": 1},
+                retrieved_at=datetime(2026, 5, 27, 9, 0, tzinfo=timezone.utc),
+            ),
+            settings=settings,
+            output_dir=workspace / "audit-2",
+        )
+        changed_dir = _persist_pipeline_result(
+            _pipeline_result(
+                run_id="run-3",
+                input_content="changed",
+                finding_metadata={"alpha": 1, "beta": 2},
+            ),
+            settings=settings,
+            output_dir=workspace / "audit-3",
+        )
+
+        first = _read_json(first_dir / "run_metadata.json")
+        second = _read_json(second_dir / "run_metadata.json")
+        changed = _read_json(changed_dir / "run_metadata.json")
+
+        assert first["input_hash"] == second["input_hash"]
+        assert first["output_hash"] == second["output_hash"]
+        assert changed["input_hash"] != first["input_hash"]
+        assert changed["output_hash"] == first["output_hash"]
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
+
+
 def test_blocked_preflight_does_not_mix_with_existing_output_directory() -> None:
     workspace = _make_workspace()
     try:
@@ -144,11 +267,206 @@ def test_blocked_preflight_does_not_mix_with_existing_output_directory() -> None
         shutil.rmtree(workspace, ignore_errors=True)
 
 
-def _agent_result(summary: str) -> AgentResult:
+def test_audit_output_hash_changes_with_semantic_output() -> None:
+    workspace = _make_workspace()
+    try:
+        settings = load_settings(repo_root=workspace, env={}, env_file=workspace / ".env.missing")
+        first_dir = _persist_pipeline_result(
+            _pipeline_result(run_id="run-output-1", input_content="same"),
+            settings=settings,
+            output_dir=workspace / "audit-output-1",
+        )
+        changed_dir = _persist_pipeline_result(
+            _pipeline_result(
+                run_id="run-output-2",
+                input_content="same",
+                result_summary="semantic change",
+            ),
+            settings=settings,
+            output_dir=workspace / "audit-output-2",
+        )
+
+        first = _read_json(first_dir / "run_metadata.json")
+        changed = _read_json(changed_dir / "run_metadata.json")
+
+        assert changed["input_hash"] == first["input_hash"]
+        assert changed["output_hash"] != first["output_hash"]
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_audit_input_hash_tracks_request_prompt_and_provider_changes() -> None:
+    workspace = _make_workspace()
+    try:
+        settings = load_settings(repo_root=workspace, env={}, env_file=workspace / ".env.missing")
+        variants = {
+            "base": _pipeline_result_with_audit_inputs(run_id="run-components-base"),
+            "operational_timestamp": _pipeline_result_with_audit_inputs(
+                run_id="run-components-time",
+                request_generated_at="2026-05-27T10:00:00+00:00",
+            ),
+            "request": _pipeline_result_with_audit_inputs(
+                run_id="run-components-request",
+                request_mode="changed",
+            ),
+            "prompt": _pipeline_result_with_audit_inputs(
+                run_id="run-components-prompt",
+                prompt_text="changed prompt",
+            ),
+            "provider": _pipeline_result_with_audit_inputs(
+                run_id="run-components-provider",
+                provider_model="changed-model",
+            ),
+        }
+        hashes = {}
+        for name, result in variants.items():
+            output_dir = _persist_pipeline_result(
+                result,
+                settings=settings,
+                output_dir=workspace / f"audit-components-{name}",
+            )
+            hashes[name] = _read_json(output_dir / "run_metadata.json")["input_hash"]
+
+        assert hashes["operational_timestamp"] == hashes["base"]
+        assert hashes["request"] != hashes["base"]
+        assert hashes["prompt"] != hashes["base"]
+        assert hashes["provider"] != hashes["base"]
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_audit_serialization_converts_non_finite_values_to_null() -> None:
+    workspace = _make_workspace()
+    try:
+        settings = load_settings(repo_root=workspace, env={}, env_file=workspace / ".env.missing")
+        output_dir = _persist_pipeline_result(
+            _pipeline_result(
+                run_id="run-json",
+                input_content="strict",
+                extra_metadata={
+                    "nan": float("nan"),
+                    "positive_infinity": float("inf"),
+                    "negative_infinity": float("-inf"),
+                    "numpy_integer": np.int64(7),
+                },
+            ),
+            settings=settings,
+            output_dir=workspace / "audit-json",
+        )
+
+        payload = _read_json(output_dir / "input_payload.json")
+        assert payload["inputs"][0]["metadata"]["nan"] is None
+        assert payload["inputs"][0]["metadata"]["positive_infinity"] is None
+        assert payload["inputs"][0]["metadata"]["negative_infinity"] is None
+        assert payload["inputs"][0]["metadata"]["numpy_integer"] == 7
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_audit_writer_redacts_credentials_from_all_json_artifacts() -> None:
+    workspace = _make_workspace()
+    try:
+        settings = load_settings(repo_root=workspace, env={}, env_file=workspace / ".env.missing")
+        base_result = _pipeline_result(
+            run_id="run-redacted",
+            input_content="strict",
+            extra_metadata={
+                "token": "sentinel-input-token",  # pragma: allowlist secret
+            },
+            finding_metadata={
+                "apiKey": "sentinel-finding-key",  # pragma: allowlist secret
+            },
+        )
+        result = replace(
+            base_result,
+            agent_requests={
+                "monitor_tematico": AgentRequest(
+                    input_refs=("investment_brief",),
+                    metadata={
+                        "apiKey": "sentinel-request-key",  # pragma: allowlist secret
+                    },
+                )
+            },
+        )
+
+        output_dir = _persist_pipeline_result(
+            result,
+            settings=settings,
+            output_dir=workspace / "audit-redacted",
+        )
+
+        serialized = "\n".join(
+            path.read_text(encoding="utf-8")
+            for path in output_dir.rglob("*.json")
+        )
+        assert "sentinel-input-token" not in serialized
+        assert "sentinel-request-key" not in serialized
+        assert "sentinel-finding-key" not in serialized
+        assert "[REDACTED]" in serialized
+        request = _read_json(
+            output_dir / "agents" / "monitor_tematico" / "request.json"
+        )
+        assert request["metadata"]["apiKey"] == "[REDACTED]"
+
+        other_base = _pipeline_result(
+            run_id="run-redacted-other",
+            input_content="strict",
+            extra_metadata={
+                "token": "different-input-token",  # pragma: allowlist secret
+            },
+            finding_metadata={
+                "apiKey": "different-finding-key",  # pragma: allowlist secret
+            },
+        )
+        other_result = replace(
+            other_base,
+            agent_requests={
+                "monitor_tematico": AgentRequest(
+                    input_refs=("investment_brief",),
+                    metadata={
+                        "apiKey": "different-request-key",  # pragma: allowlist secret
+                    },
+                )
+            },
+        )
+        other_dir = _persist_pipeline_result(
+            other_result,
+            settings=settings,
+            output_dir=workspace / "audit-redacted-other",
+        )
+        assert (
+            _read_json(other_dir / "run_metadata.json")["input_hash"]
+            == _read_json(output_dir / "run_metadata.json")["input_hash"]
+        )
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
+
+
+def _agent_result(
+    summary: str,
+    *,
+    retrieved_at: datetime | None = None,
+    finding_metadata: dict | None = None,
+) -> AgentResult:
+    source = AgentSource(
+        source_type="derived",
+        label="Test source",
+        location="derived://test-source",
+        retrieved_at=retrieved_at
+        or datetime(2026, 5, 26, 8, 0, tzinfo=timezone.utc),
+    )
     return AgentResult(
         status="success",
         summary=summary,
-        findings=(AgentFinding(title="Finding", detail="Detail"),),
+        findings=(
+            AgentFinding(
+                title="Finding",
+                detail="Detail",
+                sources=(source,),
+                metadata=finding_metadata or {},
+            ),
+        ),
+        sources=(source,),
         metadata={
             "agent_plan": ("Plan step",),
             "selected_actions": ("test_action",),
@@ -179,6 +497,88 @@ def _preflight_payload(*, status: str, can_run_agents: bool) -> dict:
             "min_return_coverage_ratio": 0.8,
         },
     }
+
+
+def _pipeline_result(
+    *,
+    run_id: str,
+    input_content: str,
+    input_location: str = "manual://investment-brief",
+    extra_metadata: dict | None = None,
+    result_summary: str | None = None,
+    retrieved_at: datetime | None = None,
+    finding_metadata: dict | None = None,
+) -> MonthlyAgentPipelineResult:
+    return MonthlyAgentPipelineResult(
+        run_id=run_id,
+        as_of_date=date(2026, 5, 26),
+        input_refs=(
+            AgentInputRef(
+                key="investment_brief",
+                label="Investment brief",
+                location=input_location,
+                source_type="manual",
+                as_of_date=date(2026, 5, 26),
+                metadata={"content": input_content, **(extra_metadata or {})},
+            ),
+        ),
+        monitor_tematico=_agent_result(
+            "monitor ok",
+            retrieved_at=retrieved_at,
+            finding_metadata=finding_metadata,
+        ),
+        analista_activos=_agent_result(
+            "asset ok",
+            retrieved_at=retrieved_at,
+            finding_metadata=finding_metadata,
+        ),
+        asistente_aportacion_mensual=_agent_result(
+            result_summary or "assistant ok",
+            retrieved_at=retrieved_at,
+            finding_metadata=finding_metadata,
+        ),
+    )
+
+
+def _pipeline_result_with_audit_inputs(
+    *,
+    run_id: str,
+    request_mode: str = "base",
+    request_generated_at: str = "2026-05-26T10:00:00+00:00",
+    prompt_text: str = "base prompt",
+    provider_model: str = "base-model",
+) -> MonthlyAgentPipelineResult:
+    result = _pipeline_result(run_id=run_id, input_content="same")
+    return replace(
+        result,
+        agent_requests={
+            "monitor_tematico": AgentRequest(
+                parameters={"mode": request_mode},
+                input_refs=("investment_brief",),
+                metadata={"generated_at": request_generated_at},
+            )
+        },
+        prompt_audits={
+            "monitor_tematico": {
+                "prompt_refs": {
+                    "schema_version": 2,
+                    "agent_name": "monitor_tematico",
+                    "prompts": [{"key": "test.prompt", "version": "v1"}],
+                },
+                "prompt_rendered": prompt_text,
+            }
+        },
+        provider_configs={
+            "monitor_tematico": {
+                "llm": {
+                    "role": "llm",
+                    "provider": "test",
+                    "model": provider_model,
+                    "options": {"temperature": 0},
+                }
+            }
+        },
+    )
 
 
 def _make_workspace() -> Path:

--- a/tests/test_agent_portfolio_targets.py
+++ b/tests/test_agent_portfolio_targets.py
@@ -7,6 +7,7 @@ import pandas as pd
 import pytest
 
 from src.agents import run_monthly_agent_pipeline
+from src.application import GetAgentRunAuditRequest, GetAgentRunAuditUseCase
 from src.config import default_repo_root, load_settings
 from src.portfolio import PortfolioMetricsResult
 
@@ -57,7 +58,11 @@ def test_monthly_agent_pipeline_passes_portfolio_targets_to_contribution_agent(w
         metrics=_metrics(),
         llm_provider="static",
         search_provider="null",
-        persist=False,
+        persist=True,
+        request_scope={"universe": "current_portfolio"},
+        request_parameters={"max_findings": 4},
+        request_constraints={"network": "offline"},
+        request_metadata={"origin": "test"},
     )
 
     target_ref = next(input_ref for input_ref in result.input_refs if input_ref.key == "target_weights")
@@ -65,6 +70,50 @@ def test_monthly_agent_pipeline_passes_portfolio_targets_to_contribution_agent(w
     assert target_ref.metadata["weights"] == {"core": 0.80, "satellite": 0.20}
     assert result.asistente_aportacion_mensual.metadata["monthly_budget"] == 900
     assert result.asistente_aportacion_mensual.metadata["target_weights"] == {"core": 0.80, "satellite": 0.20}
+
+    common_input_keys = tuple(input_ref.key for input_ref in result.input_refs)
+    expected_input_refs = {
+        "monitor_tematico": common_input_keys,
+        "analista_activos": (*common_input_keys, "monitor_tematico_result"),
+        "asistente_aportacion_mensual": (
+            *common_input_keys,
+            "monitor_tematico_result",
+            "analista_activos_result",
+        ),
+    }
+    for agent_name, request in result.agent_requests.items():
+        assert request.scope == {"universe": "current_portfolio"}
+        assert request.parameters == {"max_findings": 4}
+        assert request.constraints == {"network": "offline"}
+        assert request.metadata == {"origin": "test"}
+        assert request.input_refs == expected_input_refs[agent_name]
+        assert tuple(
+            input_ref["key"]
+            for input_ref in result.agent_contexts[agent_name]["input_refs"]
+        ) == expected_input_refs[agent_name]
+
+    assert result.raw_responses["monitor_tematico"]["status"] == "not_captured"
+    assert set(result.raw_responses["monitor_tematico"]["providers"]) == {"llm", "search"}
+    assert (
+        result.raw_responses["monitor_tematico"]["providers"]["search"]["reason_code"]
+        == "deterministic_provider_no_raw_response"
+    )
+    assert "api_key" not in str(result.provider_configs).lower()
+
+    audit = GetAgentRunAuditUseCase(settings=settings).execute(
+        GetAgentRunAuditRequest(run_id=result.run_id)
+    )
+    assert audit.schema_version == 2
+    assert audit.is_legacy is False
+    assert audit.run_metadata["input_hash"].startswith("sha256:")
+    for agent_name, expected_refs in expected_input_refs.items():
+        persisted = audit.agents[agent_name]
+        assert persisted["request"]["input_refs"] == list(expected_refs)
+        assert persisted["request"]["scope"] == {"universe": "current_portfolio"}
+        assert persisted["provider"]["providers"]["llm"]["provider"] == "static_llm"
+        assert persisted["audit_metadata"]["hash_projection"] == "semantic-v1"
+    monitor_raw = audit.agents["monitor_tematico"]["raw_response"]
+    assert set(monitor_raw["providers"]) == {"llm", "search"}
 
 
 def _metrics() -> PortfolioMetricsResult:

--- a/tests/test_agent_provider_audit.py
+++ b/tests/test_agent_provider_audit.py
@@ -1,0 +1,292 @@
+"""Focused tests for secret-safe provider audit metadata."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from src.agents import provider_audit
+from src.agents.analista_activos.llm import OpenAIAssetLLMProvider
+from src.agents.asistente_aportacion_mensual.llm import (
+    OpenAIContributionLLMProvider,
+)
+from src.agents.monitor_tematico.llm import (
+    OpenAIThemeLLMProvider,
+    StaticThemeLLMProvider,
+    ThemeLLMProviderError,
+)
+
+
+class _ConfiguredProvider:
+    name = "openai"
+    model = "test-model"
+    timeout_seconds = 15.0
+    api_key = "sentinel-secret-api-key"  # pragma: allowlist secret
+    arbitrary_internal_option = "must-not-be-persisted"
+    endpoint = "https://user:password@example.test/v1?api_key=sentinel-query"  # pragma: allowlist secret
+
+
+class _FakeResponse:
+    def model_dump(self, *, mode: str) -> dict[str, object]:
+        assert mode == "json"
+        return {
+            "id": "resp_test",
+            "model": "test-model",
+            "output": [{"type": "message", "text": "resultado"}],
+            "usage": {"input_tokens": 10, "output_tokens": 4},
+        }
+
+
+def test_provider_audit_config_only_includes_allowlisted_fields() -> None:
+    payload = provider_audit.provider_audit_config(_ConfiguredProvider(), role="llm")
+
+    assert payload == {
+        "role": "llm",
+        "provider": "openai",
+        "model": "test-model",
+        "options": {
+            "timeout_seconds": 15.0,
+            "endpoint": "https://example.test/v1",
+            "response_format": "json_schema",
+        },
+    }
+    serialized = json.dumps(payload)
+    assert "api_key" not in serialized
+    assert "sentinel-secret-api-key" not in serialized
+    assert "sentinel-query" not in serialized
+    assert "password" not in serialized
+    assert "arbitrary_internal_option" not in serialized
+
+    class NoSchemeEndpointProvider(_ConfiguredProvider):
+        endpoint = "user:password@example.test/v1?token=sentinel-query"  # pragma: allowlist secret
+
+    no_scheme = provider_audit.provider_audit_config(
+        NoSchemeEndpointProvider(),
+        role="llm",
+    )
+    assert no_scheme["options"]["endpoint"] == "example.test/v1"
+
+
+def test_recorded_model_dump_response_is_exposed_by_audit_snapshot() -> None:
+    provider = _ConfiguredProvider()
+
+    provider_audit.record_provider_raw_response(
+        provider,
+        _FakeResponse(),
+        operation="structured_analysis",
+    )
+
+    payload = provider_audit.provider_raw_response_audit(provider, role="llm")
+    assert payload["status"] == "captured"
+    assert payload["reason_code"] is None
+    assert payload["responses"] == [
+        {
+            "operation": "structured_analysis",
+            "response": {
+                "id": "resp_test",
+                "model": "test-model",
+                "output": [{"type": "message", "text": "resultado"}],
+                "usage": {"input_tokens": 10, "output_tokens": 4},
+            },
+        }
+    ]
+
+
+def test_recorded_response_redacts_nested_sensitive_keys() -> None:
+    class SensitiveResponse:
+        def model_dump(self, *, mode: str) -> dict[str, object]:
+            assert mode == "json"
+            return {
+                "id": "resp_sensitive",
+                "Authorization": "Bearer sentinel-auth",  # pragma: allowlist secret
+                "nested": {
+                    "api_key": "sentinel-nested",  # pragma: allowlist secret
+                    "apiKey": "sentinel-camel",  # pragma: allowlist secret
+                    "token": "sentinel-token",  # pragma: allowlist secret
+                    "headers": [
+                        ["Authorization", "Bearer sentinel-header"],  # pragma: allowlist secret
+                    ],
+                    "output_text": "resultado",
+                },
+            }
+
+    provider = _ConfiguredProvider()
+    provider_audit.record_provider_raw_response(
+        provider,
+        SensitiveResponse(),
+        operation="sensitive_test",
+    )
+
+    serialized = json.dumps(
+        provider_audit.provider_raw_response_audit(provider, role="llm")
+    )
+    assert "sentinel-auth" not in serialized
+    assert "sentinel-nested" not in serialized
+    assert "sentinel-camel" not in serialized
+    assert "sentinel-token" not in serialized
+    assert "sentinel-header" not in serialized
+    assert serialized.count("[REDACTED]") == 5
+
+
+def test_static_provider_has_stable_no_raw_response_reason() -> None:
+    payload = provider_audit.provider_raw_response_audit(
+        StaticThemeLLMProvider(),
+        role="llm",
+    )
+
+    assert payload["status"] == "not_captured"
+    assert payload["reason_code"] == "deterministic_provider_no_raw_response"
+    assert payload["responses"] == []
+    assert payload["provider"]["provider"] == "static_llm"
+
+
+def test_failed_provider_request_uses_stable_reason_without_exception_text() -> None:
+    provider = _ConfiguredProvider()
+    provider_audit.record_provider_failure(
+        provider,
+        operation="structured_analysis",
+    )
+
+    payload = provider_audit.provider_raw_response_audit(provider, role="llm")
+
+    assert payload["status"] == "not_captured"
+    assert payload["reason_code"] == "provider_request_failed_before_response"
+    assert payload["failures"] == [
+        {
+            "operation": "structured_analysis",
+            "reason_code": "provider_request_failed_before_response",
+        }
+    ]
+
+
+def test_raw_capture_serialization_failure_does_not_escape() -> None:
+    class BrokenResponse:
+        def model_dump(self, *, mode: str) -> dict[str, object]:
+            raise RuntimeError("serialization failed")
+
+    provider = _ConfiguredProvider()
+
+    provider_audit.record_provider_raw_response(
+        provider,
+        BrokenResponse(),
+        operation="structured_analysis",
+    )
+    payload = provider_audit.provider_raw_response_audit(provider, role="llm")
+
+    assert payload["status"] == "not_captured"
+    assert payload["reason_code"] == "raw_response_serialization_failed"
+
+
+def test_provider_aggregate_reports_every_role_and_partial_capture() -> None:
+    llm_provider = _ConfiguredProvider()
+    provider_audit.record_provider_raw_response(
+        llm_provider,
+        _FakeResponse(),
+        operation="structured_analysis",
+    )
+
+    payload = provider_audit.providers_raw_response_audit(
+        {
+            "llm": llm_provider,
+            "search": StaticThemeLLMProvider(),
+        }
+    )
+
+    assert payload["status"] == "partial"
+    assert payload["reason_code"] == "one_or_more_provider_responses_not_captured"
+    assert set(payload["providers"]) == {"llm", "search"}
+    assert payload["responses"][0]["role"] == "llm"
+
+
+@pytest.mark.parametrize(
+    "provider_type",
+    [
+        OpenAIThemeLLMProvider,
+        OpenAIAssetLLMProvider,
+        OpenAIContributionLLMProvider,
+    ],
+)
+def test_openai_provider_records_sdk_response_after_successful_call(
+    provider_type,
+) -> None:
+    class OpenAIResponse(_FakeResponse):
+        output_text = '{"ok": true}'
+
+    class Responses:
+        def create(self, **kwargs):
+            assert kwargs["model"] == "audit-model"
+            return OpenAIResponse()
+
+    provider = provider_type(
+        model="audit-model",
+        api_key="sentinel-secret-api-key",  # pragma: allowlist secret
+    )
+    provider._client = SimpleNamespace(responses=Responses())
+
+    parsed = provider._call_structured(
+        system_prompt="system",
+        user_payload={"input": "value"},
+        schema_name="audit_schema",
+        schema={"type": "object"},
+    )
+    audit = provider_audit.provider_raw_response_audit(provider, role="llm")
+
+    assert parsed == {"ok": True}
+    assert audit["status"] == "captured"
+    assert audit["responses"][0]["operation"] == "audit_schema"
+    assert "sentinel-secret-api-key" not in json.dumps(audit)
+
+
+def test_openai_provider_records_failure_before_response() -> None:
+    class FailingResponses:
+        def create(self, **kwargs):
+            raise RuntimeError("provider unavailable")
+
+    provider = OpenAIThemeLLMProvider(
+        model="audit-model",
+        api_key="sentinel-secret-api-key",  # pragma: allowlist secret
+    )
+    provider._client = SimpleNamespace(responses=FailingResponses())
+
+    with pytest.raises(ThemeLLMProviderError, match="OpenAI request failed"):
+        provider._call_structured(
+            system_prompt="system",
+            user_payload={"input": "value"},
+            schema_name="audit_schema",
+            schema={"type": "object"},
+        )
+
+    audit = provider_audit.provider_raw_response_audit(provider, role="llm")
+    assert audit["status"] == "not_captured"
+    assert audit["reason_code"] == "provider_request_failed_before_response"
+
+
+@dataclass(frozen=True)
+class _NestedAuditValue:
+    as_of_date: date
+    labels: tuple[str, ...]
+
+
+def test_json_safe_normalizes_basic_nested_values() -> None:
+    payload = provider_audit._json_safe(
+        {
+            "generated_at": datetime(2026, 7, 30, 12, 30, tzinfo=timezone.utc),
+            "nested": _NestedAuditValue(
+                as_of_date=date(2026, 7, 30),
+                labels=("uno", "dos"),
+            ),
+        }
+    )
+
+    assert payload == {
+        "generated_at": "2026-07-30T12:30:00+00:00",
+        "nested": {
+            "as_of_date": "2026-07-30",
+            "labels": ["uno", "dos"],
+        },
+    }
+    json.dumps(payload, allow_nan=False)

--- a/tests/test_application_layer.py
+++ b/tests/test_application_layer.py
@@ -403,6 +403,81 @@ def test_agent_audit_use_cases_read_persisted_run() -> None:
         assert audit.input_payload["inputs"][0]["key"] == "investment_brief"
         assert audit.agents["monitor_tematico"]["parsed_output"]["metadata"]["agent_plan"] == ["step"]
         assert audit.agents["monitor_tematico"]["prompt_rendered"] == "# prompt\n"
+        assert audit.agents["monitor_tematico"]["provider"] == {}
+        assert audit.agents["monitor_tematico"]["audit_metadata"] == {}
+        assert audit.schema_version == 1
+        assert audit.is_legacy is True
+        assert audit.compatibility_warnings
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_agent_audit_reader_redacts_credentials_defensively() -> None:
+    workspace = make_test_workspace()
+    try:
+        settings = load_settings(repo_root=workspace, env={}, env_file=workspace / ".env.missing")
+        run_dir = settings.data_dir / "agents" / "monthly_pipeline" / "run-secure"
+        agent_dir = run_dir / "agents" / "monitor_tematico"
+        _write_json(
+            run_dir / "run_metadata.json",
+            {
+                "run_id": "run-secure",
+                "schema_version": 2,
+                "token": "sentinel-run-token",  # pragma: allowlist secret
+            },
+        )
+        _write_json(
+            run_dir / "input_payload.json",
+            {
+                "metadata": {
+                    "apiKey": "sentinel-input-key",  # pragma: allowlist secret
+                }
+            },
+        )
+        _write_json(
+            agent_dir / "request.json",
+            {
+                "metadata": {
+                    "bearer_token": "sentinel-request-token",  # pragma: allowlist secret
+                }
+            },
+        )
+        _write_json(
+            agent_dir / "provider.json",
+            {"provider": "legacy", "api_key": "sentinel-provider-secret"},  # pragma: allowlist secret
+        )
+        _write_json(
+            agent_dir / "raw_response.json",
+            {
+                "status": "captured",
+                "responses": [
+                    {
+                        "Authorization": "Bearer sentinel-authorization",  # pragma: allowlist secret
+                        "output_text": "safe output",
+                    }
+                ],
+            },
+        )
+
+        audit = GetAgentRunAuditUseCase(settings=settings).execute(
+            GetAgentRunAuditRequest(run_id="run-secure")
+        )
+
+        serialized = json.dumps(
+            {
+                "run_metadata": audit.run_metadata,
+                "input_payload": audit.input_payload,
+                "agent": audit.agents["monitor_tematico"],
+            }
+        )
+        assert "sentinel-provider-secret" not in serialized
+        assert "sentinel-authorization" not in serialized
+        assert "sentinel-run-token" not in serialized
+        assert "sentinel-input-key" not in serialized
+        assert "sentinel-request-token" not in serialized
+        assert serialized.count("[REDACTED]") == 5
+        assert audit.schema_version == 2
+        assert audit.is_legacy is False
     finally:
         shutil.rmtree(workspace, ignore_errors=True)
 
@@ -470,6 +545,10 @@ def test_run_monthly_agents_use_case_wraps_pipeline(monkeypatch) -> None:
                 search_provider="null",
                 persist=False,
                 monthly_budget=1500.0,
+                request_scope={"universe": "portfolio"},
+                request_parameters={"max_findings": 4},
+                request_constraints={"network": "offline"},
+                request_metadata={"origin": "test"},
             )
         )
     finally:
@@ -481,6 +560,10 @@ def test_run_monthly_agents_use_case_wraps_pipeline(monkeypatch) -> None:
     assert captured["metrics"] is metrics
     assert captured["persist"] is False
     assert captured["monthly_budget"] == 1500.0
+    assert captured["request_scope"] == {"universe": "portfolio"}
+    assert captured["request_parameters"] == {"max_findings": 4}
+    assert captured["request_constraints"] == {"network": "offline"}
+    assert captured["request_metadata"] == {"origin": "test"}
     assert result.result.status == "partial"
     assert result.quality_result.can_run_agents is True
     assert result.result.artifacts["run_id"] == "run-001"

--- a/tests/test_dashboard_transforms.py
+++ b/tests/test_dashboard_transforms.py
@@ -3,6 +3,7 @@ from datetime import date
 import pandas as pd
 
 from src.portfolio import PortfolioMetricsResult
+from src.portfolio.dashboard_agents import _raw_response_summary
 from src.portfolio.dashboard_transforms import _build_asset_evolution_frame
 
 
@@ -60,3 +61,24 @@ def test_asset_evolution_starts_on_first_buy_date() -> None:
 
     assert frame["valuation_date"].tolist() == [date(2026, 1, 2), date(2026, 1, 3)]
     assert frame["Asset A"].tolist() == [0.0, 9.09090909]
+
+
+def test_agent_raw_summary_hides_nested_response_bodies() -> None:
+    raw_response = {
+        "status": "captured",
+        "providers": {
+            "llm": {
+                "status": "captured",
+                "provider": {"provider": "openai", "model": "test-model"},
+                "responses": [{"response": {"output_text": "private body"}}],
+            }
+        },
+        "responses": [{"role": "llm", "response": {"output_text": "private body"}}],
+    }
+
+    summary = _raw_response_summary(raw_response)
+
+    assert "responses" not in summary
+    assert "responses" not in summary["providers"]["llm"]
+    assert summary["providers"]["llm"]["provider"]["model"] == "test-model"
+    assert "private body" not in str(summary)

--- a/tests/test_monitor_tematico.py
+++ b/tests/test_monitor_tematico.py
@@ -23,6 +23,7 @@ from src.agents.monitor_tematico import (
     build_observed_topics,
 )
 import src.agents.monitor_tematico.providers as search_providers
+from src.agents.provider_audit import provider_raw_response_audit
 from src.config import default_repo_root, load_settings
 
 
@@ -397,3 +398,6 @@ def test_tavily_search_provider_requires_api_key(monkeypatch: pytest.MonkeyPatch
             end_date=date(2026, 5, 26),
             max_results=2,
         )
+
+    audit = provider_raw_response_audit(provider, role="search")
+    assert audit["reason_code"] == "provider_configuration_missing"


### PR DESCRIPTION
## Resumen
- Persiste requests, contextos, prompts, providers y hashes semánticos por agente.
- Captura respuestas disponibles, reason codes estables y redacción de secretos.
- Mantiene compatibilidad legacy y expone la auditoría en Streamlit.

## Validación
- 182 tests; cobertura 73,97%.
- Ruff, mypy, demo y detect-secrets correctos.

Closes #40