### PR TITLE
Laboratorio determinista de aportación

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,11 +34,11 @@ La UI actual es Streamlit. Una futura API/FastAPI debe entrar casi siempre por `
   `GetPortfolioStateUseCase`, `SaveDegiroUploadsUseCase`,
   `InferFxRequirementsUseCase`, `RunMonitorTematicoUseCase`,
   `UpdateInvestmentBriefUseCase`, `ReadPortfolioTargetsUseCase`,
-  `UpdatePortfolioTargetsUseCase` y los casos operativos de importacion,
-  refresh, informes y agentes.
+  `UpdatePortfolioTargetsUseCase`, `SimulateContributionUseCase` y los casos
+  operativos de importacion, refresh, informes y agentes.
 - Manten entradas como dataclasses `*Request` y salidas estructuradas. Para acciones operativas usa `ApplicationResult`.
 - No dupliques calculos financieros en `src/application/`; coordina servicios de dominio existentes.
-- `src/portfolio/dashboard.py` debe seguir siendo entrypoint fino de Streamlit. Las vistas viven en `dashboard_overview.py`, `dashboard_reports.py`, `dashboard_data_update.py` y `dashboard_agents.py`.
+- `src/portfolio/dashboard.py` debe seguir siendo entrypoint fino de Streamlit. Las vistas viven en `dashboard_overview.py`, `dashboard_contribution_lab.py`, `dashboard_reports.py`, `dashboard_data_update.py` y `dashboard_agents.py`.
 - No metas logica de UI en dominio ni queries/repositorios directos en Streamlit si existe caso de uso equivalente.
 - Los datos de cartera salen de exportaciones oficiales DEGIRO y artefactos derivados validados. Los agentes no deben inventar estado de cartera.
 - Preserva auditoria de agentes: plan interno, acciones permitidas/usadas/descartadas, fuentes, prompts, warnings, inputs y outputs.
@@ -60,6 +60,12 @@ Invariantes y errores tipicos:
 - No llames desde Streamlit a `src.agents`, `src.reports`, `src.market_data` o importadores si ya hay caso de uso en `src/application/`.
 - No aceptes YAML libre de targets desde interfaces: usa un mapping JSON
   estructurado y `UpdatePortfolioTargetsUseCase`.
+- El laboratorio de aportacion es siempre `contributions_only`: solo puede
+  proponer compras de posiciones actuales valoradas y mapeadas. No vende, no
+  ejecuta ordenes y muestra la caja residual separada de los pesos posteriores.
+- No infieras buckets por nombres: `asset_bucket_mapping` debe resolver de forma
+  exacta cada `asset_id` o ISIN activo contra un bucket de
+  `target_allocation`.
 - No cambies prompts/agentes sin mantener la auditoria: plan, acciones, fuentes, prompts, warnings, inputs y outputs.
 
 ## Como ejecutar tests
@@ -85,6 +91,7 @@ Tests focalizados frecuentes:
 .\.venv\Scripts\python.exe -m pytest tests\test_dashboard_transforms.py
 .\.venv\Scripts\python.exe -m pytest tests\test_streamlit_dashboard_smoke.py
 .\.venv\Scripts\python.exe -m pytest tests\test_public_documentation.py
+.\.venv\Scripts\python.exe -m pytest tests\test_contribution_planner.py tests\test_contribution_application.py
 ```
 
 Mapa rapido de tests por area:
@@ -97,7 +104,7 @@ Mapa rapido de tests por area:
 | Preflight de agentes | `tests\test_data_quality.py`, `tests\test_application_layer.py`, `tests\test_agent_audit_trail.py`, `tests\test_run_monthly_agents_cli.py` |
 | Dashboard | `tests\test_dashboard_transforms.py`, `tests\test_streamlit_dashboard_uploads.py` |
 | DEGIRO/importacion | `tests\test_degiro_*.py` |
-| Portfolio/metricas | `tests\test_portfolio_metrics.py`, `tests\test_positions.py`, `tests\test_portfolio_state_projection.py`, `tests\test_portfolio_contributions.py` |
+| Portfolio/metricas y laboratorio | `tests\test_portfolio_metrics.py`, `tests\test_positions.py`, `tests\test_portfolio_state_projection.py`, `tests\test_portfolio_contributions.py`, `tests\test_contribution_planner.py`, `tests\test_contribution_application.py` |
 | Market data/FX | `tests\test_market_data.py`, `tests\test_fx_refresh.py` |
 | Defaults offline | `tests\test_agent_safe_defaults.py`, `tests\test_demo_workspace.py` |
 | Documentacion/publicacion | `tests\test_public_documentation.py`, `tests\test_dev_commands.py` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ proyecto usa [versionado semántico](https://semver.org/lang/es/).
   control optimista por hash.
 - Contratos completos para leer y actualizar `portfolio_targets` mediante JSON
   validado, escritura atómica y control optimista por hash.
+- Laboratorio determinista de aportación con compras sobre posiciones
+  existentes, límites configurables, caja residual y comparación de pesos antes
+  y después, sin ventas ni ejecución de órdenes.
 - Proyección reutilizable de estado/PnL y cálculo centralizado de aportaciones
   externas para dashboard, informes y futuras interfaces.
 - Providers `synthetic` de precios y FX que mantienen la demo completamente

--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ viven en rutas locales ignoradas por Git y la demo publica usa datos sinteticos.
 - Reconstruccion diaria de posiciones y metricas agregadas de cartera.
 - Refresco de FX y precios con politica `broker_snapshot_anchored`.
 - Informe mensual en Markdown.
-- Dashboard Streamlit para cartera, evolucion, informes, actualizacion de datos y agentes.
+- Laboratorio determinista para simular aportaciones sobre posiciones actuales,
+  sin ventas ni ejecucion de ordenes.
+- Dashboard Streamlit para cartera, aportaciones, evolucion, informes,
+  actualizacion de datos y agentes.
 - Agentes mensuales con prompts versionados y auditoria visual.
 - Demo sintetica ejecutable sin exponer datos reales.
 
@@ -82,10 +85,11 @@ Guia completa: `demo/README.md`.
 
 ## Resultado sintetico reproducible
 
-Tras preparar la demo, el dashboard muestra una cartera ficticia, su evolucion,
-un informe mensual y la auditoria de los tres agentes. Los datos, el brief, los
-precios y las respuestas `static` estan etiquetados como sinteticos y no
-representan una cartera ni una recomendacion real.
+Tras preparar la demo, el dashboard muestra una cartera ficticia, una simulacion
+determinista de aportacion, su evolucion, un informe mensual y la auditoria de
+los tres agentes. Los datos, el brief, los precios y las respuestas `static`
+estan etiquetados como sinteticos y no representan una cartera ni una
+recomendacion real.
 
 La vista se genera desde `demo/synthetic_config/.env.demo` y
 `demo/local_data/`; no contiene datos de una cartera real. Puedes reproducirla

--- a/demo/README.md
+++ b/demo/README.md
@@ -86,6 +86,7 @@ como baseline: no genera contexto de busqueda y el monitor puede quedar
 En la demo puedes mostrar:
 
 - vista general de cartera ficticia;
+- laboratorio determinista de aportacion sobre las posiciones sinteticas;
 - evolucion y metricas;
 - informe mensual demo;
 - agentes con plan interno, acciones usadas, restricciones y trazabilidad.
@@ -123,7 +124,8 @@ O abre una terminal nueva y ejecuta el dashboard normal:
 
 - `synthetic_config/investment_brief.md`: mandato ficticio.
 - `synthetic_config/portfolio_targets.yaml`: objetivos ficticios con el mismo
-  contrato estructurado que lee y guarda la UI.
+  contrato estructurado que lee y guarda la UI, incluido el mapping exacto
+  entre activos sinteticos y buckets.
 - `synthetic_degiro_exports/incoming/transactions_2026-01-15_2026-04-30.csv`
 - `synthetic_degiro_exports/incoming/account_2026-01-15_2026-04-30.csv`
 - `synthetic_degiro_exports/incoming/portfolio_2026-04-30.csv`
@@ -131,5 +133,8 @@ O abre una terminal nueva y ejecuta el dashboard normal:
 Limitaciones:
 
 - La demo no pretende modelar una cartera real.
+- El laboratorio solo propone compras de posiciones actuales valoradas y
+  mapeadas. No vende ni ejecuta ordenes; la caja residual se muestra aparte y
+  no entra en los pesos posteriores.
 - Los precios sinteticos solo cubren el periodo necesario para mostrar el flujo.
 - Los agentes en modo `static/static` devuelven resultados deterministas de demo.

--- a/demo/synthetic_config/portfolio_targets.yaml
+++ b/demo/synthetic_config/portfolio_targets.yaml
@@ -6,6 +6,11 @@ target_allocation:
   defensive_bonds: 25
   satellites: 10
   cash: 10
+asset_bucket_mapping:
+  degiro:isin:IE00SYNCORE1: core_global_equity
+  degiro:isin:IE00SYNBOND1: defensive_bonds
+  degiro:isin:NL00SYNTECH1: satellites
+  degiro:cash:eur: cash
 max_single_asset_weight: 35
 max_sector_weight: 30
 rebalance_mode: contributions_only

--- a/docs/api_contracts.md
+++ b/docs/api_contracts.md
@@ -500,7 +500,129 @@ Notas:
   `GET /api/v1/agents/monthly-runs/{run_id}/artifacts/{artifact_name}` con una
   allowlist estricta.
 
-## 7. Cambiar brief y targets
+## 7. Simular una aportacion
+
+### `POST /api/v1/portfolio/contribution-simulations`
+
+Calcula un reparto determinista de una aportacion sin modificar la cartera ni
+ejecutar ordenes.
+
+Caso de uso base:
+
+- `SimulateContributionUseCase`.
+
+Request:
+
+```json
+{
+  "contribution_amount": 450.0,
+  "allow_fractional_units": false,
+  "minimum_order_value": 25.0,
+  "max_orders": 4,
+  "as_of_date": null
+}
+```
+
+Todos los campos son opcionales. Si se omite `contribution_amount`, se usa
+`monthly_contribution` de los targets persistidos. La request no admite estado
+de cartera, targets ni `asset_bucket_mapping`: el caso de uso debe obtenerlos
+localmente mediante `GetPortfolioStateUseCase(persist=False)` y
+`ReadPortfolioTargetsUseCase`.
+
+Respuesta representativa:
+
+```json
+{
+  "status": "succeeded",
+  "message": "Contribution simulation completed.",
+  "warnings": [],
+  "artifacts": {
+    "as_of_date": "2026-05-31",
+    "budget": 450.0,
+    "invested_amount": 400.0,
+    "remaining_cash": 50.0,
+    "order_count": 1,
+    "targets_hash": "sha256:..."
+  },
+  "assumptions": [
+    "contributions_only_no_sales",
+    "current_positions_only",
+    "no_fees_taxes_slippage",
+    "implied_unit_price_from_market_value",
+    "deterministic_identifier_tiebreak",
+    "remaining_cash_excluded_from_after_weights",
+    "deviation_is_half_l1_bucket_distance",
+    "whole_units_only"
+  ],
+  "simulation": {
+    "as_of_date": "2026-05-31",
+    "base_currency": "EUR",
+    "targets_content_hash": "sha256:...",
+    "budget": 450.0,
+    "invested_amount": 400.0,
+    "remaining_cash": 50.0,
+    "deviation_before": 0.02,
+    "deviation_after": 0.009230769231,
+    "orders": [
+      {
+        "asset_id": "degiro:isin:IE00SYNCORE1",
+        "isin": "IE00SYNCORE1",
+        "bucket": "core",
+        "quantity": 4.0,
+        "unit_price_base": 100.0,
+        "amount_base": 400.0,
+        "weight_before": 0.72,
+        "weight_after": 0.730769230769
+      }
+    ],
+    "bucket_allocations": [
+      {
+        "bucket": "core",
+        "target_weight": 0.74,
+        "value_before": 7200.0,
+        "value_after": 7600.0,
+        "weight_before": 0.72,
+        "weight_after": 0.730769230769,
+        "deviation_before": 0.02,
+        "deviation_after": 0.009230769231,
+        "allocated_amount": 400.0
+      }
+    ],
+    "constraints": {
+      "contribution_amount": 450.0,
+      "allow_fractional_units": false,
+      "minimum_order_value": 25.0,
+      "max_orders": 4,
+      "max_single_asset_weight": 0.8
+    },
+    "constraint_events": [
+      "whole_units_unaffordable:degiro:isin:IE00SYNCORE1",
+      "budget_residual:50.0"
+    ]
+  }
+}
+```
+
+Notas:
+
+- Solo se proponen compras de posiciones actuales con valoracion, mapping
+  exacto y precio unitario utilizable. No se crean activos nuevos.
+- La simulacion es `contributions_only`: nunca devuelve ventas, cantidades
+  negativas ni ejecucion de ordenes.
+- El total propuesto no supera el presupuesto. La caja residual queda fuera
+  del denominador de los pesos posteriores y se devuelve por separado.
+- `deviation_before` y `deviation_after` son la mitad de la distancia L1 entre
+  pesos por bucket y sus objetivos.
+- No se fuerza una compra: si ninguna mejora la desviacion respetando los
+  limites, la respuesta conserva los pesos y devuelve `orders: []`.
+- Una posicion activa sin mapping, identificador o valoracion bloquea el plan
+  completo con `status: partial`, warnings y cero compras; el caso de uso no
+  inventa buckets. Un precio unitario inutilizable excluye solo ese activo,
+  conserva `status: partial` y permite proponer otros activos validos.
+- La respuesta es JSON estricto: no expone `Path`, `DataFrame`, valores no
+  finitos ni tipos de pandas/numpy.
+
+## 8. Cambiar brief y targets
 
 ### `GET /api/v1/settings/investment-brief`
 
@@ -579,6 +701,10 @@ Respuesta:
       "core": 0.8,
       "satellite": 0.2
     },
+    "asset_bucket_mapping": {
+      "degiro:isin:IE00SYNCORE1": "core",
+      "degiro:isin:NL00SYNTECH1": "satellite"
+    },
     "max_single_asset_weight": 0.2,
     "max_sector_weight": 0.3,
     "rebalance_mode": "contributions_only"
@@ -620,6 +746,10 @@ Request:
       "core": 0.8,
       "satellite": 0.2
     },
+    "asset_bucket_mapping": {
+      "degiro:isin:IE00SYNCORE1": "core",
+      "degiro:isin:NL00SYNTECH1": "satellite"
+    },
     "max_single_asset_weight": 0.2,
     "max_sector_weight": 0.3,
     "rebalance_mode": "contributions_only"
@@ -647,6 +777,10 @@ Respuesta:
       "core": 0.8,
       "satellite": 0.2
     },
+    "asset_bucket_mapping": {
+      "degiro:isin:IE00SYNCORE1": "core",
+      "degiro:isin:NL00SYNTECH1": "satellite"
+    },
     "max_single_asset_weight": 0.2,
     "max_sector_weight": 0.3,
     "rebalance_mode": "contributions_only"
@@ -664,6 +798,8 @@ Notas:
 - La entrada es un objeto JSON, no YAML libre. El caso de uso valida con
   `portfolio_targets_from_mapping`, normaliza porcentajes a decimales y exige
   que `target_allocation` sume `1.0` o `100`.
+- `asset_bucket_mapping` relaciona de forma exacta un `asset_id` o ISIN con un
+  bucket existente en `target_allocation`; no se infiere por nombres.
 - `target_weights` se admite como alias al leer configuraciones antiguas, pero
   las interfaces nuevas deben emitir `target_allocation`.
 - La persistencia serializa JSON canonico en la ruta configurada por

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,7 +42,9 @@ Fronteras ya disponibles:
 - `ReadInvestmentBriefUseCase` y `UpdateInvestmentBriefUseCase` para leer y
   guardar el mandato local sin escribir desde la interfaz;
 - `ReadPortfolioTargetsUseCase` y `UpdatePortfolioTargetsUseCase` para leer,
-  validar y guardar objetivos estructurados con control de concurrencia.
+  validar y guardar objetivos estructurados con control de concurrencia;
+- `SimulateContributionUseCase` para combinar el estado local, los targets
+  validados y el planificador puro de aportaciones sin ejecutar ordenes.
 
 Las acciones operativas devuelven `ApplicationResult`. Los read models
 destinados a adaptadores externos, como estado de cartera y requisitos FX,
@@ -84,6 +86,9 @@ Estado actual de esta capa:
 - proyecciones compartidas de snapshot broker, coste y PnL en
   `state_projection.py`,
 - consultas de aportaciones externas en `contributions.py`,
+- planificacion determinista `contributions_only` en
+  `contribution_planner.py`, limitada a posiciones actuales valoradas y
+  mapeadas,
 - y una base directa para reporting y Streamlit.
 
 Responsable de reconstrucción histórica de posiciones, métricas agregadas e interfaz de Streamlit.
@@ -106,7 +111,7 @@ DEGIRO exports
     -> refresco de FX/precios
     -> reconstruccion historica
     -> metricas ancladas a snapshots DEGIRO
-    -> informes
+    -> simulacion de aportacion / informes
     -> agentes
     -> Streamlit
 ```
@@ -146,10 +151,10 @@ src/portfolio/dashboard.py
 ```
 
 `dashboard.py` actua como entrypoint y navegacion. Las pestanas viven en modulos
-especificos (`dashboard_overview.py`, `dashboard_reports.py`,
-`dashboard_data_update.py`, `dashboard_agents.py`) y los helpers compartidos en
-`dashboard_common.py`. Esta separacion reduce acoplamiento antes de una posible
-interfaz web futura.
+especificos (`dashboard_overview.py`, `dashboard_contribution_lab.py`,
+`dashboard_reports.py`, `dashboard_data_update.py`, `dashboard_agents.py`) y los
+helpers compartidos en `dashboard_common.py`. Esta separacion reduce
+acoplamiento antes de una posible interfaz web futura.
 
 ## Direccion v2
 

--- a/docs/streamlit_dashboard.md
+++ b/docs/streamlit_dashboard.md
@@ -38,6 +38,9 @@ en la terminal.
 ## Vistas incluidas
 
 - `Vista general`: asignacion actual y valor total de la ultima fecha valorada. El ultimo snapshot DEGIRO se muestra como ancla, pero la fecha principal puede avanzar con market data posterior. Incluye `Actualizar a hoy` para refrescar FX y precios sin importar nuevos CSVs.
+- `Aportacion`: laboratorio determinista para repartir una aportacion entre
+  posiciones actuales valoradas y mapeadas. Compara pesos antes/despues,
+  muestra restricciones y caja residual, pero no vende ni ejecuta ordenes.
 - `Evolucion`: valor historico calculado por activo. DEGIRO fija el precio local de referencia en cada snapshot y market data aporta la variacion relativa diaria, sin aplicar un segundo anclaje global.
 - `Informes`: lectura de informes mensuales generados en `reports_history` o en la carpeta de informes.
 - `Actualizar datos`: subida de CSVs DEGIRO, importacion, carga DuckDB, refresh FX, refresh precios e informe mensual.
@@ -55,6 +58,8 @@ pagina, pinta el sidebar y conecta las pestanas. La logica visual vive en
 modulos separados:
 
 - `dashboard_overview.py`: `Vista general`, `Evolucion` y refresh a hoy.
+- `dashboard_contribution_lab.py`: formulario y resultado del laboratorio de
+  aportacion.
 - `dashboard_reports.py`: lectura y generacion de informes.
 - `dashboard_data_update.py`: subida de CSVs e import/refresh de datos.
 - `dashboard_agents.py`: inputs, ejecucion y visualizacion de agentes.
@@ -82,6 +87,30 @@ No importa nuevos CSVs ni cambia el snapshot de broker disponible. Si quieres qu
 la cartera incluya nuevas compras, ventas, movimientos de efectivo o cantidades
 oficiales de DEGIRO, primero debes subir/importar las exportaciones en
 `Actualizar datos`.
+
+## Laboratorio de aportacion
+
+La pestana `Aportacion` llama a `SimulateContributionUseCase`; no carga
+repositorios ni replica calculos financieros desde Streamlit. El formulario
+permite ajustar:
+
+- presupuesto de la aportacion, usando por defecto `monthly_contribution`;
+- unidades enteras o fraccionarias;
+- valor minimo por compra;
+- numero maximo de compras.
+
+El caso de uso obtiene el estado con `GetPortfolioStateUseCase(persist=False)` y
+lee los targets configurados. La interfaz no envia estado, targets ni mappings
+en la request. `asset_bucket_mapping` debe relacionar de forma exacta cada
+`asset_id` o ISIN activo con un bucket de `target_allocation`; nunca se infiere
+por el nombre del activo.
+
+La simulacion es exclusivamente `contributions_only`: propone como maximo
+compras de posiciones existentes, valoradas y comprables. No genera ventas, no
+modifica datos y no ejecuta ordenes. Si falta valoracion o mapping, el resultado
+es parcial y muestra warnings en lugar de inventar una asignacion. La caja no
+invertida queda fuera del denominador de los pesos posteriores y aparece como
+`Efectivo restante`.
 
 ## Flujo desde la UI
 
@@ -202,6 +231,7 @@ Casos de uso operativos:
 - `RefreshFxUseCase`
 - `RefreshMarketDataUseCase`
 - `GenerateMonthlyReportUseCase`
+- `SimulateContributionUseCase`
 - `RunMonthlyAgentsUseCase`
 - `UpdateInvestmentBriefUseCase`
 - `UpdatePortfolioTargetsUseCase`
@@ -246,6 +276,11 @@ contrato completo en `Portfolio targets persistentes`. El editor acepta un
 objeto JSON, nunca YAML libre. Al guardar, `UpdatePortfolioTargetsUseCase`
 valida pesos, aportacion y limites, normaliza porcentajes a decimales y
 reemplaza atomica y exclusivamente la ruta configurada.
+
+El contrato incluye `asset_bucket_mapping`, cuyas claves son identificadores
+exactos (`asset_id` o ISIN) y cuyos valores deben existir en
+`target_allocation`. El laboratorio bloquea una asignacion incompleta de
+posiciones activas para mantener reproducible la comparacion antes/despues.
 
 La UI conserva el hash cargado para no sobrescribir cambios realizados desde
 otra sesion. Si el archivo cambia, obliga a recargar; si ya existe pero es

--- a/src/application/README.md
+++ b/src/application/README.md
@@ -34,6 +34,8 @@ que la interfaz no dependa de detalles internos de `src/portfolio/`,
   opcional de concurrencia mediante hash;
 - leer y actualizar `portfolio_targets` completos mediante un mapping JSON
   validado, escritura atomica y control opcional de concurrencia mediante hash;
+- simular una aportacion determinista con estado y targets locales validados,
+  sin aceptar esos datos desde la interfaz ni ejecutar ordenes;
 - guardar uploads DEGIRO con nombres normalizados antes de importarlos.
 
 Las migraciones deben ser progresivas: primero se anade el wrapper, despues se
@@ -97,6 +99,15 @@ la ruta como texto, el hash del contenido y cualquier error de validacion.
 `UpdatePortfolioTargetsUseCase` recibe datos estructurados, valida con el mismo
 contrato del dominio y solo reemplaza atomica y controladamente la ruta
 configurada en `Settings.portfolio_targets_path`.
+
+`SimulateContributionUseCase` carga ese contrato y
+`GetPortfolioStateUseCase(persist=False)`, adapta solo posiciones actuales
+valoradas y resuelve su bucket mediante `asset_bucket_mapping`. Delega el
+calculo al planificador puro de cartera y devuelve una respuesta JSON estricta
+con compras propuestas, pesos antes/despues, restricciones y caja residual. La
+simulacion es `contributions_only`: nunca vende ni ejecuta ordenes. El efectivo
+no invertido queda fuera del denominador de los pesos posteriores y se informa
+por separado.
 
 ## Relacion con v2
 

--- a/src/application/__init__.py
+++ b/src/application/__init__.py
@@ -87,6 +87,11 @@ from src.application.portfolio_state import (
     GetPortfolioStateResult,
     GetPortfolioStateUseCase,
 )
+from src.application.contribution_lab import (
+    SimulateContributionRequest,
+    SimulateContributionResult,
+    SimulateContributionUseCase,
+)
 from src.application.monitor import (
     RunMonitorTematicoRequest,
     RunMonitorTematicoResult,
@@ -170,6 +175,9 @@ __all__ = [
     "SaveDegiroUploadsRequest",
     "SaveDegiroUploadsResult",
     "SaveDegiroUploadsUseCase",
+    "SimulateContributionRequest",
+    "SimulateContributionResult",
+    "SimulateContributionUseCase",
     "extract_report_as_of_date_from_path",
     "extract_monthly_report_as_of_date",
     "net_external_contributions_until",

--- a/src/application/contribution_lab.py
+++ b/src/application/contribution_lab.py
@@ -1,0 +1,532 @@
+"""Application boundary for deterministic contribution simulations."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import math
+from typing import Any, Mapping
+
+from src.application.portfolio_state import (
+    GetPortfolioStateRequest,
+    GetPortfolioStateUseCase,
+)
+from src.application.portfolio_targets import ReadPortfolioTargetsUseCase
+from src.application.serialization import json_ready_value
+from src.application.types import ApplicationResult, ApplicationStatus
+from src.config import Settings, get_settings
+from src.portfolio.contribution_planner import (
+    ContributionConstraints,
+    ContributionPosition,
+    plan_contribution,
+)
+
+
+_BASE_ASSUMPTIONS = (
+    "contributions_only_no_sales",
+    "current_positions_only",
+    "no_fees_taxes_slippage",
+    "implied_unit_price_from_market_value",
+    "deterministic_identifier_tiebreak",
+    "remaining_cash_excluded_from_after_weights",
+)
+
+
+@dataclass(frozen=True)
+class SimulateContributionRequest:
+    """User-controlled simulation parameters; state and targets stay server-side."""
+
+    contribution_amount: float | None = None
+    allow_fractional_units: bool = False
+    minimum_order_value: float = 0.0
+    max_orders: int = 4
+    as_of_date: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class SimulateContributionResult:
+    result: ApplicationResult
+    simulation: dict[str, Any] | None
+    assumptions: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a strict JSON-ready response envelope."""
+        return json_ready_value(
+            {
+                "status": self.result.status,
+                "message": self.result.message,
+                "warnings": list(self.result.warnings),
+                "artifacts": dict(self.result.artifacts),
+                "assumptions": list(self.assumptions),
+                "simulation": self.simulation,
+            }
+        )
+
+
+@dataclass(frozen=True)
+class _PositionAdaptation:
+    positions: tuple[ContributionPosition, ...]
+    warnings: tuple[str, ...]
+    constraint_events: tuple[str, ...]
+    incomplete_mapping: bool = False
+    error: str | None = None
+
+
+class SimulateContributionUseCase:
+    """Compose validated local state and targets around the pure planner."""
+
+    name = "simulate_contribution"
+
+    def __init__(
+        self,
+        *,
+        settings: Settings | None = None,
+        state_use_case: GetPortfolioStateUseCase | None = None,
+        targets_use_case: ReadPortfolioTargetsUseCase | None = None,
+    ) -> None:
+        self.settings = get_settings() if settings is None else settings
+        self.state_use_case = state_use_case or GetPortfolioStateUseCase(
+            settings=self.settings
+        )
+        self.targets_use_case = targets_use_case or ReadPortfolioTargetsUseCase(
+            settings=self.settings
+        )
+
+    def execute(
+        self,
+        request: SimulateContributionRequest | None = None,
+    ) -> SimulateContributionResult:
+        resolved_request = request or SimulateContributionRequest()
+        request_error = _validate_request(resolved_request)
+        if request_error:
+            return self._failed(request_error)
+
+        targets_state = self.targets_use_case.execute()
+        if targets_state.validation_error:
+            return self._failed(
+                f"Portfolio targets are invalid: {targets_state.validation_error}"
+            )
+        targets = targets_state.portfolio_targets
+        if targets is None:
+            return self._failed("Portfolio targets are not configured.")
+
+        target_weights = targets.get("target_allocation")
+        raw_mapping = targets.get("asset_bucket_mapping")
+        if not isinstance(target_weights, Mapping) or not target_weights:
+            return self._failed("Portfolio targets do not contain target_allocation.")
+        if not isinstance(raw_mapping, Mapping) or not raw_mapping:
+            return self._failed(
+                "Portfolio targets require a non-empty asset_bucket_mapping."
+            )
+
+        contribution_amount = (
+            resolved_request.contribution_amount
+            if resolved_request.contribution_amount is not None
+            else targets.get("monthly_contribution")
+        )
+        contribution_error = _validate_positive_number(
+            contribution_amount,
+            field_name="contribution_amount",
+        )
+        if contribution_error:
+            return self._failed(contribution_error)
+        assert contribution_amount is not None
+        budget = float(contribution_amount)
+
+        assumptions = list(_BASE_ASSUMPTIONS)
+        rebalance_mode = targets.get("rebalance_mode")
+        if rebalance_mode is None:
+            assumptions.append("rebalance_mode_defaulted_to_contributions_only")
+        elif rebalance_mode != "contributions_only":
+            return self._failed(
+                "Portfolio targets must use rebalance_mode='contributions_only'."
+            )
+
+        try:
+            state = self.state_use_case.execute(
+                GetPortfolioStateRequest(
+                    persist=False,
+                    include_positions=True,
+                    include_history=False,
+                    as_of_date=resolved_request.as_of_date,
+                )
+            )
+        except (FileNotFoundError, ValueError) as exc:
+            return self._failed(f"Portfolio state is unavailable: {exc}")
+
+        target_currency = str(targets.get("base_currency") or "").upper()
+        if target_currency and target_currency != state.base_currency.upper():
+            return self._failed(
+                "Portfolio state and targets use different base currencies."
+            )
+
+        adaptation = _adapt_positions(
+            state.positions,
+            asset_bucket_mapping=raw_mapping,
+        )
+        if adaptation.error:
+            return self._failed(adaptation.error)
+
+        constraints_payload = {
+            "contribution_amount": budget,
+            "allow_fractional_units": resolved_request.allow_fractional_units,
+            "minimum_order_value": float(resolved_request.minimum_order_value),
+            "max_orders": resolved_request.max_orders,
+            "max_single_asset_weight": targets.get("max_single_asset_weight"),
+        }
+        state_warnings = tuple(
+            str(warning)
+            for warning in (state.data_quality.get("warnings") or [])
+        )
+        warnings = tuple(dict.fromkeys((*state_warnings, *adaptation.warnings)))
+
+        if adaptation.incomplete_mapping:
+            simulation = _empty_simulation(
+                as_of_date=state.as_of_date,
+                base_currency=state.base_currency,
+                targets_content_hash=targets_state.content_hash,
+                budget=budget,
+                constraints=constraints_payload,
+                constraint_events=adaptation.constraint_events,
+            )
+            return self._completed(
+                status="partial",
+                message=(
+                    "Contribution simulation skipped because active positions "
+                    "are incomplete or not fully mapped."
+                ),
+                warnings=warnings,
+                assumptions=tuple(assumptions),
+                simulation=simulation,
+                targets_hash=targets_state.content_hash,
+            )
+
+        constraints = ContributionConstraints(
+            contribution_amount=budget,
+            allow_fractional_units=resolved_request.allow_fractional_units,
+            minimum_order_value=float(resolved_request.minimum_order_value),
+            max_orders=resolved_request.max_orders,
+            max_single_asset_weight=_optional_float(
+                targets.get("max_single_asset_weight")
+            ),
+        )
+        try:
+            plan = plan_contribution(
+                adaptation.positions,
+                {str(key): float(value) for key, value in target_weights.items()},
+                constraints,
+            )
+        except ValueError as exc:
+            return self._failed(f"Contribution simulation is invalid: {exc}")
+
+        plan_payload = plan.to_dict()
+        plan_warnings = tuple(
+            str(warning) for warning in (plan_payload.pop("warnings", []) or [])
+        )
+        plan_assumptions = tuple(
+            str(assumption)
+            for assumption in (plan_payload.pop("assumptions", []) or [])
+        )
+        combined_warnings = tuple(
+            dict.fromkeys((*warnings, *plan_warnings))
+        )
+        combined_assumptions = tuple(
+            dict.fromkeys((*assumptions, *plan_assumptions))
+        )
+        existing_events = tuple(
+            str(event)
+            for event in (plan_payload.get("constraint_events") or [])
+        )
+        plan_payload["constraint_events"] = list(
+            dict.fromkeys((*adaptation.constraint_events, *existing_events))
+        )
+        simulation = json_ready_value(
+            {
+                "as_of_date": state.as_of_date,
+                "base_currency": state.base_currency,
+                "targets_content_hash": targets_state.content_hash,
+                "constraints": constraints_payload,
+                **plan_payload,
+            }
+        )
+        has_incomplete_data = (
+            bool(state_warnings)
+            or any(
+                warning.startswith("unusable_unit_price:")
+                for warning in adaptation.warnings
+            )
+            or bool(
+                {"no_current_positions", "no_buyable_positions", "planning_round_limit_reached"}
+                & set(plan_warnings)
+            )
+            or any(
+                event.startswith("non_finite_quantity:")
+                for event in plan_payload["constraint_events"]
+            )
+        )
+        status: ApplicationStatus = (
+            "partial" if has_incomplete_data else "succeeded"
+        )
+        message = (
+            "Contribution simulation completed with data warnings."
+            if status == "partial"
+            else "Contribution simulation completed."
+        )
+        return self._completed(
+            status=status,
+            message=message,
+            warnings=combined_warnings,
+            assumptions=combined_assumptions,
+            simulation=simulation,
+            targets_hash=targets_state.content_hash,
+        )
+
+    def _completed(
+        self,
+        *,
+        status: ApplicationStatus,
+        message: str,
+        warnings: tuple[str, ...],
+        assumptions: tuple[str, ...],
+        simulation: dict[str, Any],
+        targets_hash: str,
+    ) -> SimulateContributionResult:
+        return SimulateContributionResult(
+            result=ApplicationResult(
+                name=self.name,
+                status=status,
+                message=message,
+                warnings=warnings,
+                artifacts={
+                    "as_of_date": str(simulation.get("as_of_date") or ""),
+                    "budget": _artifact_float(simulation.get("budget")),
+                    "invested_amount": _artifact_float(
+                        simulation.get("invested_amount")
+                    ),
+                    "remaining_cash": _artifact_float(
+                        simulation.get("remaining_cash")
+                    ),
+                    "order_count": len(simulation.get("orders") or []),
+                    "targets_hash": targets_hash,
+                },
+            ),
+            simulation=simulation,
+            assumptions=assumptions,
+        )
+
+    def _failed(self, message: str) -> SimulateContributionResult:
+        return SimulateContributionResult(
+            result=ApplicationResult(
+                name=self.name,
+                status="failed",
+                message=message,
+            ),
+            simulation=None,
+            assumptions=_BASE_ASSUMPTIONS,
+        )
+
+
+def _validate_request(request: SimulateContributionRequest) -> str | None:
+    if not isinstance(request.allow_fractional_units, bool):
+        return "allow_fractional_units must be boolean."
+    minimum_error = _validate_non_negative_number(
+        request.minimum_order_value,
+        field_name="minimum_order_value",
+    )
+    if minimum_error:
+        return minimum_error
+    if isinstance(request.max_orders, bool) or not isinstance(
+        request.max_orders, int
+    ):
+        return "max_orders must be an integer."
+    if request.max_orders <= 0:
+        return "max_orders must be greater than zero."
+    if request.contribution_amount is not None:
+        return _validate_positive_number(
+            request.contribution_amount,
+            field_name="contribution_amount",
+        )
+    return None
+
+
+def _validate_positive_number(value: Any, *, field_name: str) -> str | None:
+    error = _validate_finite_number(value, field_name=field_name)
+    if error:
+        return error
+    assert value is not None
+    if float(value) <= 0:
+        return f"{field_name} must be greater than zero."
+    return None
+
+
+def _validate_non_negative_number(value: Any, *, field_name: str) -> str | None:
+    error = _validate_finite_number(value, field_name=field_name)
+    if error:
+        return error
+    assert value is not None
+    if float(value) < 0:
+        return f"{field_name} cannot be negative."
+    return None
+
+
+def _validate_finite_number(value: Any, *, field_name: str) -> str | None:
+    if value is None or isinstance(value, bool):
+        return f"{field_name} must be a finite number."
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return f"{field_name} must be a finite number."
+    if not math.isfinite(parsed):
+        return f"{field_name} must be a finite number."
+    return None
+
+
+def _adapt_positions(
+    raw_positions: list[dict[str, Any]],
+    *,
+    asset_bucket_mapping: Mapping[Any, Any],
+) -> _PositionAdaptation:
+    mapping = {
+        str(identifier): str(bucket)
+        for identifier, bucket in asset_bucket_mapping.items()
+    }
+    casefold_mapping: dict[str, list[tuple[str, str]]] = {}
+    for identifier, bucket in mapping.items():
+        casefold_mapping.setdefault(identifier.casefold(), []).append(
+            (identifier, bucket)
+        )
+
+    positions: list[ContributionPosition] = []
+    warnings: list[str] = []
+    constraint_events: list[str] = []
+    used_mapping_keys: set[str] = set()
+    incomplete_mapping = False
+
+    for raw in [dict(position) for position in raw_positions]:
+        asset_id = str(raw.get("asset_id") or "").strip()
+        value = _optional_float(raw.get("market_value_base"))
+        if not asset_id:
+            if value is not None and value > 0:
+                warnings.append("missing_asset_id")
+                constraint_events.append("position_excluded:missing_asset_id")
+                incomplete_mapping = True
+            continue
+        if value is None or value < 0:
+            warnings.append(f"invalid_market_value:{asset_id}")
+            constraint_events.append(f"position_excluded:{asset_id}")
+            incomplete_mapping = True
+            continue
+        if value <= 1e-9:
+            continue
+
+        isin = str(raw.get("isin") or "").strip() or None
+        candidate_entries: list[tuple[str, str]] = []
+        if asset_id in mapping:
+            candidate_entries.append((asset_id, mapping[asset_id]))
+        if isin:
+            candidate_entries.extend(casefold_mapping.get(isin.casefold(), []))
+        candidate_entries = list(dict.fromkeys(candidate_entries))
+        candidate_buckets = {bucket for _, bucket in candidate_entries}
+        if len(candidate_buckets) > 1:
+            return _PositionAdaptation(
+                positions=(),
+                warnings=(),
+                constraint_events=(),
+                error=(
+                    f"Conflicting asset_bucket_mapping entries for {asset_id!r}."
+                ),
+            )
+        if not candidate_entries:
+            warnings.append(f"missing_asset_bucket_mapping:{asset_id}")
+            constraint_events.append(f"position_unmapped:{asset_id}")
+            incomplete_mapping = True
+            continue
+        bucket = candidate_entries[0][1]
+        used_mapping_keys.update(key for key, _ in candidate_entries)
+        if len(candidate_entries) > 1:
+            warnings.append(f"duplicate_mapping_alias:{asset_id}")
+
+        asset_type = str(raw.get("asset_type") or "").strip() or None
+        quantity = _optional_float(raw.get("quantity"))
+        unit_price: float | None = None
+        normalized_quantity = quantity if quantity is not None and quantity >= 0 else 0.0
+        is_cash = (
+            (asset_type or "").casefold() == "cash"
+            or asset_id.casefold().startswith("degiro:cash:")
+        )
+        if not is_cash:
+            if quantity is not None and quantity > 0:
+                unit_price = value / quantity
+            else:
+                warnings.append(f"unusable_unit_price:{asset_id}")
+                constraint_events.append(f"asset_not_buyable:{asset_id}")
+
+        positions.append(
+            ContributionPosition(
+                asset_id=asset_id,
+                isin=isin,
+                bucket=bucket,
+                quantity=normalized_quantity,
+                market_value_base=value,
+                unit_price_base=unit_price,
+                asset_type=asset_type,
+            )
+        )
+
+    for identifier in sorted(set(mapping) - used_mapping_keys):
+        warnings.append(f"unused_mapping_entry:{identifier}")
+    return _PositionAdaptation(
+        positions=tuple(positions),
+        warnings=tuple(warnings),
+        constraint_events=tuple(constraint_events),
+        incomplete_mapping=incomplete_mapping,
+    )
+
+
+def _empty_simulation(
+    *,
+    as_of_date: str,
+    base_currency: str,
+    targets_content_hash: str,
+    budget: float,
+    constraints: dict[str, Any],
+    constraint_events: tuple[str, ...],
+) -> dict[str, Any]:
+    return {
+        "as_of_date": as_of_date,
+        "base_currency": base_currency,
+        "targets_content_hash": targets_content_hash,
+        "budget": budget,
+        "invested_amount": 0.0,
+        "remaining_cash": budget,
+        "deviation_before": None,
+        "deviation_after": None,
+        "orders": [],
+        "bucket_allocations": [],
+        "constraints": constraints,
+        "constraint_events": list(constraint_events),
+    }
+
+
+def _optional_float(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if math.isfinite(parsed) else None
+
+
+def _artifact_float(value: Any) -> float | None:
+    parsed = _optional_float(value)
+    return parsed
+
+
+__all__ = [
+    "SimulateContributionRequest",
+    "SimulateContributionResult",
+    "SimulateContributionUseCase",
+]

--- a/src/data/README.md
+++ b/src/data/README.md
@@ -22,9 +22,11 @@ Artefactos relevantes ya en uso:
 - `market_data/asset_overrides.csv`: overrides manuales para tickers, proxies o exclusiones del refresh.
 - `normalized/degiro/`: salida normalizada de los parsers DEGIRO, usada tambien para bootstrap de `assets_master`.
 - `portfolio_targets.yaml`: objetivos privados de cartera, pesos objetivo,
-  aportacion mensual y limites de concentracion. Hay un ejemplo versionado en
-  `sample/portfolio_targets.example.yaml`. Streamlit lo lee y actualiza mediante
-  los casos de uso estructurados de `src/application/`, no como YAML libre.
+  aportacion mensual, limites de concentracion y `asset_bucket_mapping` exacto
+  para asociar `asset_id` o ISIN con un bucket objetivo. Hay un ejemplo
+  versionado en `sample/portfolio_targets.example.yaml`. Streamlit lo lee y
+  actualiza mediante los casos de uso estructurados de `src/application/`, no
+  como YAML libre.
 - `investment_brief.md`: mandato narrativo privado de la cuenta. Hay un ejemplo
   versionado en `sample/investment_brief.example.md`.
 

--- a/src/data/sample/portfolio_targets.example.yaml
+++ b/src/data/sample/portfolio_targets.example.yaml
@@ -6,6 +6,11 @@ target_allocation:
   ETFs: 70
   stocks: 20
   cash: 10
+asset_bucket_mapping:
+  degiro:isin:IE00SYNCORE1: ETFs
+  degiro:isin:IE00SYNBOND1: ETFs
+  degiro:isin:NL00SYNTECH1: stocks
+  degiro:cash:eur: cash
 max_single_asset_weight: 15
 max_sector_weight: 30
 rebalance_mode: contributions_only

--- a/src/portfolio/contribution_planner.py
+++ b/src/portfolio/contribution_planner.py
@@ -1,0 +1,742 @@
+"""Pure deterministic planner for contributions-only portfolio simulations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Any, Mapping, Sequence
+
+
+_EPSILON = 1e-9
+_MAX_PLANNING_ROUNDS = 512
+
+
+@dataclass(frozen=True)
+class ContributionPosition:
+    """Current valued position adapted at the application boundary."""
+
+    asset_id: str
+    bucket: str
+    quantity: float
+    market_value_base: float
+    unit_price_base: float | None
+    isin: str | None = None
+    asset_type: str | None = None
+
+
+@dataclass(frozen=True)
+class ContributionConstraints:
+    """User and target constraints accepted by the deterministic planner."""
+
+    contribution_amount: float
+    allow_fractional_units: bool = False
+    minimum_order_value: float = 0.0
+    max_orders: int = 10
+    max_single_asset_weight: float | None = None
+
+
+@dataclass(frozen=True)
+class ContributionOrder:
+    asset_id: str
+    isin: str | None
+    bucket: str
+    quantity: float
+    unit_price_base: float
+    amount_base: float
+    weight_before: float
+    weight_after: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "asset_id": self.asset_id,
+            "isin": self.isin,
+            "bucket": self.bucket,
+            "quantity": _clean(self.quantity),
+            "unit_price_base": _clean(self.unit_price_base),
+            "amount_base": _clean(self.amount_base),
+            "weight_before": _clean(self.weight_before),
+            "weight_after": _clean(self.weight_after),
+        }
+
+
+@dataclass(frozen=True)
+class BucketAllocation:
+    bucket: str
+    target_weight: float
+    value_before: float
+    value_after: float
+    weight_before: float
+    weight_after: float
+    deviation_before: float
+    deviation_after: float
+    allocated_amount: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "bucket": self.bucket,
+            "target_weight": _clean(self.target_weight),
+            "value_before": _clean(self.value_before),
+            "value_after": _clean(self.value_after),
+            "weight_before": _clean(self.weight_before),
+            "weight_after": _clean(self.weight_after),
+            "deviation_before": _clean(self.deviation_before),
+            "deviation_after": _clean(self.deviation_after),
+            "allocated_amount": _clean(self.allocated_amount),
+        }
+
+
+@dataclass(frozen=True)
+class ContributionPlan:
+    budget: float
+    invested_amount: float
+    remaining_cash: float
+    deviation_before: float
+    deviation_after: float
+    orders: tuple[ContributionOrder, ...]
+    bucket_allocations: tuple[BucketAllocation, ...]
+    constraint_events: tuple[str, ...]
+    warnings: tuple[str, ...]
+    assumptions: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return primitives only; adapters can serialize this directly."""
+        return {
+            "budget": _clean(self.budget),
+            "invested_amount": _clean(self.invested_amount),
+            "remaining_cash": _clean(self.remaining_cash),
+            "deviation_before": _clean(self.deviation_before),
+            "deviation_after": _clean(self.deviation_after),
+            "orders": [order.to_dict() for order in self.orders],
+            "bucket_allocations": [
+                allocation.to_dict() for allocation in self.bucket_allocations
+            ],
+            "constraint_events": list(self.constraint_events),
+            "warnings": list(self.warnings),
+            "assumptions": list(self.assumptions),
+        }
+
+
+@dataclass(frozen=True)
+class _Candidate:
+    position: ContributionPosition
+    amount: float
+    quantity: float
+    deviation_after: float
+
+
+def plan_contribution(
+    positions: Sequence[ContributionPosition],
+    target_weights: Mapping[str, float],
+    constraints: ContributionConstraints,
+) -> ContributionPlan:
+    """Propose deterministic buys that strictly improve bucket deviation."""
+    normalized_positions = tuple(
+        sorted(positions, key=lambda position: (position.bucket, position.asset_id))
+    )
+    normalized_targets = _validate_inputs(
+        normalized_positions,
+        target_weights,
+        constraints,
+    )
+    budget = float(constraints.contribution_amount)
+    current_total = sum(position.market_value_base for position in normalized_positions)
+    if not math.isfinite(current_total) or not math.isfinite(current_total + budget):
+        raise ValueError("Portfolio value plus contribution must remain finite.")
+    current_by_bucket = _sum_by_bucket(normalized_positions)
+    current_by_asset = {
+        position.asset_id: position.market_value_base
+        for position in normalized_positions
+    }
+    position_by_asset = {
+        position.asset_id: position for position in normalized_positions
+    }
+    allocated_by_asset: dict[str, float] = {}
+    quantity_by_asset: dict[str, float] = {}
+    events: list[str] = []
+    warnings: list[str] = []
+
+    buyable_positions: list[ContributionPosition] = []
+    for position in normalized_positions:
+        if _is_cash_position(position):
+            continue
+        if position.unit_price_base is None:
+            events.append(f"asset_not_buyable:{position.asset_id}")
+            continue
+        buyable_positions.append(position)
+
+    if not normalized_positions:
+        warnings.append("no_current_positions")
+    elif not buyable_positions:
+        warnings.append("no_buyable_positions")
+
+    deviation_before = _portfolio_deviation(
+        bucket_values=current_by_bucket,
+        total_value=current_total,
+        target_weights=normalized_targets,
+    )
+    current_deviation = deviation_before
+
+    for _round in range(_MAX_PLANNING_ROUNDS):
+        invested = math.fsum(allocated_by_asset.values())
+        remaining = budget - invested
+        if remaining <= _EPSILON:
+            break
+        if invested > 0.0:
+            # Leave one representable step of headroom so adding a later
+            # fractional allocation cannot round above the hard budget.
+            remaining = math.nextafter(remaining, 0.0)
+
+        candidate = _best_candidate(
+            positions=buyable_positions,
+            target_weights=normalized_targets,
+            current_by_bucket=current_by_bucket,
+            current_by_asset=current_by_asset,
+            allocated_by_asset=allocated_by_asset,
+            current_total=current_total,
+            remaining_budget=remaining,
+            current_deviation=current_deviation,
+            constraints=constraints,
+            events=events,
+        )
+        if candidate is None:
+            break
+
+        asset_id = candidate.position.asset_id
+        proposed_asset_amount = math.fsum(
+            (allocated_by_asset.get(asset_id, 0.0), candidate.amount)
+        )
+        proposed_invested = math.fsum(
+            (
+                *(
+                    amount
+                    for existing_asset_id, amount in allocated_by_asset.items()
+                    if existing_asset_id != asset_id
+                ),
+                proposed_asset_amount,
+            )
+        )
+        if proposed_invested > budget:
+            events.append(f"budget_precision_limit:{asset_id}")
+            break
+        try:
+            proposed_quantity = math.fsum(
+                (quantity_by_asset.get(asset_id, 0.0), candidate.quantity)
+            )
+        except OverflowError:
+            events.append(f"non_finite_quantity:{asset_id}")
+            break
+        if not math.isfinite(proposed_quantity):
+            events.append(f"non_finite_quantity:{asset_id}")
+            break
+        allocated_by_asset[asset_id] = proposed_asset_amount
+        quantity_by_asset[asset_id] = proposed_quantity
+        current_deviation = candidate.deviation_after
+    else:
+        warnings.append("planning_round_limit_reached")
+
+    invested_amount = math.fsum(allocated_by_asset.values())
+    remaining_cash = max(0.0, budget - invested_amount)
+    if remaining_cash > _EPSILON:
+        events.append(f"budget_residual:{_clean(remaining_cash)}")
+    if not allocated_by_asset and buyable_positions:
+        warnings.append("no_improving_purchase")
+
+    final_total = current_total + invested_amount
+    allocated_by_bucket: dict[str, float] = {}
+    for asset_id, amount in allocated_by_asset.items():
+        bucket = position_by_asset[asset_id].bucket
+        allocated_by_bucket[bucket] = allocated_by_bucket.get(bucket, 0.0) + amount
+
+    deviation_after = _portfolio_deviation(
+        bucket_values={
+            bucket: current_by_bucket.get(bucket, 0.0)
+            + allocated_by_bucket.get(bucket, 0.0)
+            for bucket in normalized_targets
+        },
+        total_value=final_total,
+        target_weights=normalized_targets,
+    )
+    if deviation_after > deviation_before + _EPSILON:
+        raise RuntimeError("Contribution planner produced a worsening allocation.")
+
+    orders = tuple(
+        ContributionOrder(
+            asset_id=asset_id,
+            isin=position_by_asset[asset_id].isin,
+            bucket=position_by_asset[asset_id].bucket,
+            quantity=quantity_by_asset[asset_id],
+            unit_price_base=position_by_asset[asset_id].unit_price_base or 0.0,
+            amount_base=amount,
+            weight_before=(
+                current_by_asset[asset_id] / current_total
+                if current_total > _EPSILON
+                else 0.0
+            ),
+            weight_after=(
+                (current_by_asset[asset_id] + amount) / final_total
+                if final_total > _EPSILON
+                else 0.0
+            ),
+        )
+        for asset_id, amount in sorted(allocated_by_asset.items())
+    )
+    bucket_allocations = tuple(
+        _build_bucket_allocation(
+            bucket=bucket,
+            target_weight=normalized_targets[bucket],
+            current_value=current_by_bucket.get(bucket, 0.0),
+            allocated_amount=allocated_by_bucket.get(bucket, 0.0),
+            current_total=current_total,
+            final_total=final_total,
+        )
+        for bucket in sorted(normalized_targets)
+    )
+    assumptions = (
+        "contributions_only_no_sales",
+        "current_positions_only",
+        "remaining_cash_excluded_from_after_weights",
+        "deviation_is_half_l1_bucket_distance",
+        (
+            "fractional_units_allowed"
+            if constraints.allow_fractional_units
+            else "whole_units_only"
+        ),
+    )
+    return ContributionPlan(
+        budget=_clean(budget),
+        invested_amount=_clean(invested_amount),
+        remaining_cash=_clean(remaining_cash),
+        deviation_before=_clean(deviation_before),
+        deviation_after=_clean(deviation_after),
+        orders=orders,
+        bucket_allocations=bucket_allocations,
+        constraint_events=tuple(dict.fromkeys(events)),
+        warnings=tuple(dict.fromkeys(warnings)),
+        assumptions=assumptions,
+    )
+
+
+def _best_candidate(
+    *,
+    positions: Sequence[ContributionPosition],
+    target_weights: Mapping[str, float],
+    current_by_bucket: Mapping[str, float],
+    current_by_asset: Mapping[str, float],
+    allocated_by_asset: Mapping[str, float],
+    current_total: float,
+    remaining_budget: float,
+    current_deviation: float,
+    constraints: ContributionConstraints,
+    events: list[str],
+) -> _Candidate | None:
+    invested = sum(allocated_by_asset.values())
+    simulated_total = current_total + invested
+    allocated_by_bucket: dict[str, float] = {}
+    for position in positions:
+        allocated = allocated_by_asset.get(position.asset_id, 0.0)
+        allocated_by_bucket[position.bucket] = (
+            allocated_by_bucket.get(position.bucket, 0.0) + allocated
+        )
+
+    candidates: list[_Candidate] = []
+    unique_orders = len(allocated_by_asset)
+    for position in sorted(positions, key=lambda item: (item.bucket, item.asset_id)):
+        asset_id = position.asset_id
+        is_new_order = asset_id not in allocated_by_asset
+        if is_new_order and unique_orders >= constraints.max_orders:
+            events.append("max_orders_reached")
+            continue
+
+        bucket_value = (
+            current_by_bucket.get(position.bucket, 0.0)
+            + allocated_by_bucket.get(position.bucket, 0.0)
+        )
+        target_weight = target_weights[position.bucket]
+        current_bucket_weight = (
+            bucket_value / simulated_total
+            if simulated_total > _EPSILON
+            else 0.0
+        )
+        if current_bucket_weight >= target_weight - _EPSILON:
+            continue
+
+        target_headroom = _target_headroom(
+            bucket_value=bucket_value,
+            total_value=simulated_total,
+            target_weight=target_weight,
+        )
+        cap_headroom = _asset_cap_headroom(
+            asset_value=(
+                current_by_asset[asset_id]
+                + allocated_by_asset.get(asset_id, 0.0)
+            ),
+            total_value=simulated_total,
+            cap=constraints.max_single_asset_weight,
+        )
+        if cap_headroom <= _EPSILON:
+            events.append(f"max_single_asset_weight:{asset_id}")
+            continue
+
+        candidate = _candidate_for_position(
+            position=position,
+            is_new_order=is_new_order,
+            target_headroom=target_headroom,
+            cap_headroom=cap_headroom,
+            asset_value_before_candidate=(
+                current_by_asset[asset_id]
+                + allocated_by_asset.get(asset_id, 0.0)
+            ),
+            remaining_budget=remaining_budget,
+            current_total=current_total,
+            current_by_bucket=current_by_bucket,
+            allocated_by_bucket=allocated_by_bucket,
+            allocated_by_asset=allocated_by_asset,
+            target_weights=target_weights,
+            current_deviation=current_deviation,
+            constraints=constraints,
+            events=events,
+        )
+        if candidate is not None:
+            candidates.append(candidate)
+
+    if not candidates:
+        return None
+    return min(
+        candidates,
+        key=lambda candidate: (
+            round(candidate.deviation_after, 12),
+            -round(candidate.amount, 12),
+            candidate.position.bucket,
+            candidate.position.asset_id,
+        ),
+    )
+
+
+def _candidate_for_position(
+    *,
+    position: ContributionPosition,
+    is_new_order: bool,
+    target_headroom: float,
+    cap_headroom: float,
+    asset_value_before_candidate: float,
+    remaining_budget: float,
+    current_total: float,
+    current_by_bucket: Mapping[str, float],
+    allocated_by_bucket: Mapping[str, float],
+    allocated_by_asset: Mapping[str, float],
+    target_weights: Mapping[str, float],
+    current_deviation: float,
+    constraints: ContributionConstraints,
+    events: list[str],
+) -> _Candidate | None:
+    unit_price = position.unit_price_base
+    assert unit_price is not None
+    maximum_amount = min(remaining_budget, cap_headroom)
+    desired_amount = min(maximum_amount, target_headroom)
+    minimum_amount = constraints.minimum_order_value if is_new_order else 0.0
+
+    if constraints.allow_fractional_units:
+        amount = desired_amount
+        if amount < minimum_amount:
+            amount = minimum_amount
+        if amount > maximum_amount or amount <= 0.0:
+            events.append(f"minimum_order_not_met:{position.asset_id}")
+            return None
+        quantity = amount / unit_price
+    else:
+        maximum_units_value = maximum_amount / unit_price
+        desired_units_value = desired_amount / unit_price
+        if not math.isfinite(maximum_units_value) or not math.isfinite(
+            desired_units_value
+        ):
+            events.append(f"non_finite_quantity:{position.asset_id}")
+            return None
+        maximum_units = math.floor(maximum_units_value)
+        desired_units = math.floor(desired_units_value)
+        minimum_units_value = minimum_amount / unit_price
+        if is_new_order and not math.isfinite(minimum_units_value):
+            events.append(f"non_finite_quantity:{position.asset_id}")
+            return None
+        minimum_units = (
+            max(1, math.ceil(minimum_units_value))
+            if is_new_order
+            else 1
+        )
+        units = desired_units
+        if units < minimum_units:
+            units = minimum_units
+        if units > maximum_units or units <= 0:
+            event = (
+                "minimum_order_not_met"
+                if minimum_amount > remaining_budget + _EPSILON
+                else "whole_units_unaffordable"
+            )
+            events.append(f"{event}:{position.asset_id}")
+            return None
+        try:
+            quantity = float(units)
+        except OverflowError:
+            events.append(f"non_finite_quantity:{position.asset_id}")
+            return None
+        amount = quantity * unit_price
+
+    if not math.isfinite(quantity) or not math.isfinite(amount):
+        events.append(f"non_finite_quantity:{position.asset_id}")
+        return None
+    if amount > remaining_budget or amount > cap_headroom:
+        events.append(f"hard_limit_exceeded:{position.asset_id}")
+        return None
+    if is_new_order and amount < constraints.minimum_order_value:
+        events.append(f"minimum_order_not_met:{position.asset_id}")
+        return None
+    if constraints.max_single_asset_weight is not None:
+        final_asset_weight = (
+            asset_value_before_candidate + amount
+        ) / (
+            current_total
+            + sum(allocated_by_asset.values())
+            + amount
+        )
+        if final_asset_weight > constraints.max_single_asset_weight:
+            events.append(f"max_single_asset_weight:{position.asset_id}")
+            return None
+
+    candidate_deviation = _deviation_with_candidate(
+        position=position,
+        amount=amount,
+        current_total=current_total,
+        current_by_bucket=current_by_bucket,
+        allocated_by_bucket=allocated_by_bucket,
+        allocated_by_asset=allocated_by_asset,
+        target_weights=target_weights,
+    )
+    if candidate_deviation >= current_deviation - _EPSILON:
+        events.append(f"purchase_would_not_improve:{position.asset_id}")
+        return None
+    return _Candidate(
+        position=position,
+        amount=amount,
+        quantity=quantity,
+        deviation_after=candidate_deviation,
+    )
+
+
+def _deviation_with_candidate(
+    *,
+    position: ContributionPosition,
+    amount: float,
+    current_total: float,
+    current_by_bucket: Mapping[str, float],
+    allocated_by_bucket: Mapping[str, float],
+    allocated_by_asset: Mapping[str, float],
+    target_weights: Mapping[str, float],
+) -> float:
+    total_allocated = sum(allocated_by_asset.values())
+    bucket_values = {
+        bucket: current_by_bucket.get(bucket, 0.0)
+        + allocated_by_bucket.get(bucket, 0.0)
+        for bucket in target_weights
+    }
+    bucket_values[position.bucket] = (
+        bucket_values.get(position.bucket, 0.0)
+        + amount
+    )
+    return _portfolio_deviation(
+        bucket_values=bucket_values,
+        total_value=current_total + total_allocated + amount,
+        target_weights=target_weights,
+    )
+
+
+def _target_headroom(
+    *,
+    bucket_value: float,
+    total_value: float,
+    target_weight: float,
+) -> float:
+    if target_weight >= 1.0 - _EPSILON:
+        return math.inf
+    return max(
+        0.0,
+        (target_weight * total_value - bucket_value) / (1.0 - target_weight),
+    )
+
+
+def _asset_cap_headroom(
+    *,
+    asset_value: float,
+    total_value: float,
+    cap: float | None,
+) -> float:
+    if cap is None or cap >= 1.0 - _EPSILON:
+        return math.inf
+    return max(0.0, (cap * total_value - asset_value) / (1.0 - cap))
+
+
+def _portfolio_deviation(
+    *,
+    bucket_values: Mapping[str, float],
+    total_value: float,
+    target_weights: Mapping[str, float],
+) -> float:
+    if total_value <= _EPSILON:
+        return 0.0
+    return 0.5 * sum(
+        abs(
+            (bucket_values.get(bucket, 0.0) / total_value)
+            - target_weights[bucket]
+        )
+        for bucket in sorted(target_weights)
+    )
+
+
+def _sum_by_bucket(
+    positions: Sequence[ContributionPosition],
+) -> dict[str, float]:
+    values: dict[str, float] = {}
+    for position in positions:
+        values[position.bucket] = (
+            values.get(position.bucket, 0.0) + position.market_value_base
+        )
+    return values
+
+
+def _is_cash_position(position: ContributionPosition) -> bool:
+    return (
+        (position.asset_type or "").casefold() == "cash"
+        or position.asset_id.casefold().startswith("degiro:cash:")
+    )
+
+
+def _build_bucket_allocation(
+    *,
+    bucket: str,
+    target_weight: float,
+    current_value: float,
+    allocated_amount: float,
+    current_total: float,
+    final_total: float,
+) -> BucketAllocation:
+    weight_before = (
+        current_value / current_total if current_total > _EPSILON else 0.0
+    )
+    value_after = current_value + allocated_amount
+    weight_after = value_after / final_total if final_total > _EPSILON else 0.0
+    return BucketAllocation(
+        bucket=bucket,
+        target_weight=target_weight,
+        value_before=current_value,
+        value_after=value_after,
+        weight_before=weight_before,
+        weight_after=weight_after,
+        deviation_before=abs(weight_before - target_weight),
+        deviation_after=abs(weight_after - target_weight),
+        allocated_amount=allocated_amount,
+    )
+
+
+def _validate_inputs(
+    positions: Sequence[ContributionPosition],
+    target_weights: Mapping[str, float],
+    constraints: ContributionConstraints,
+) -> dict[str, float]:
+    if not isinstance(target_weights, Mapping) or not target_weights:
+        raise ValueError("target_weights must be a non-empty mapping.")
+    targets: dict[str, float] = {}
+    for raw_bucket, raw_weight in target_weights.items():
+        bucket = str(raw_bucket).strip()
+        if not bucket or bucket in targets:
+            raise ValueError("target_weights must contain unique non-empty buckets.")
+        targets[bucket] = _finite_number(
+            raw_weight,
+            field_name=f"target_weights.{bucket}",
+            minimum=0.0,
+        )
+    if not math.isclose(sum(targets.values()), 1.0, abs_tol=1e-9):
+        raise ValueError("target_weights must sum to 1.0.")
+
+    _finite_number(
+        constraints.contribution_amount,
+        field_name="contribution_amount",
+        minimum=_EPSILON,
+    )
+    _finite_number(
+        constraints.minimum_order_value,
+        field_name="minimum_order_value",
+        minimum=0.0,
+    )
+    if not isinstance(constraints.allow_fractional_units, bool):
+        raise ValueError("allow_fractional_units must be boolean.")
+    if isinstance(constraints.max_orders, bool) or not isinstance(
+        constraints.max_orders, int
+    ):
+        raise ValueError("max_orders must be an integer.")
+    if constraints.max_orders <= 0:
+        raise ValueError("max_orders must be greater than zero.")
+    if constraints.max_single_asset_weight is not None:
+        cap = _finite_number(
+            constraints.max_single_asset_weight,
+            field_name="max_single_asset_weight",
+            minimum=0.0,
+        )
+        if cap > 1.0:
+            raise ValueError("max_single_asset_weight cannot exceed 1.0.")
+
+    seen_assets: set[str] = set()
+    for position in positions:
+        if not position.asset_id.strip() or position.asset_id in seen_assets:
+            raise ValueError("positions must contain unique non-empty asset_id values.")
+        seen_assets.add(position.asset_id)
+        if position.bucket not in targets:
+            raise ValueError(
+                f"Position {position.asset_id!r} references an unknown bucket."
+            )
+        _finite_number(
+            position.quantity,
+            field_name=f"positions.{position.asset_id}.quantity",
+            minimum=0.0,
+        )
+        _finite_number(
+            position.market_value_base,
+            field_name=f"positions.{position.asset_id}.market_value_base",
+            minimum=0.0,
+        )
+        if position.unit_price_base is not None:
+            _finite_number(
+                position.unit_price_base,
+                field_name=f"positions.{position.asset_id}.unit_price_base",
+                minimum=_EPSILON,
+            )
+    return targets
+
+
+def _finite_number(
+    value: Any,
+    *,
+    field_name: str,
+    minimum: float,
+) -> float:
+    if isinstance(value, bool):
+        raise ValueError(f"{field_name} must be a finite number.")
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be a finite number.") from exc
+    if not math.isfinite(parsed) or parsed < minimum:
+        raise ValueError(f"{field_name} must be at least {minimum}.")
+    return parsed
+
+
+def _clean(value: float) -> float:
+    parsed = float(value)
+    return 0.0 if parsed == 0.0 else parsed
+
+
+__all__ = [
+    "BucketAllocation",
+    "ContributionConstraints",
+    "ContributionOrder",
+    "ContributionPlan",
+    "ContributionPosition",
+    "plan_contribution",
+]

--- a/src/portfolio/dashboard.py
+++ b/src/portfolio/dashboard.py
@@ -21,6 +21,7 @@ from src.portfolio.dashboard_common import (
     render_hero,
     warehouse_counts,
 )
+from src.portfolio.dashboard_contribution_lab import render_contribution_lab_tab
 from src.portfolio.dashboard_data_update import render_update_tab
 from src.portfolio.dashboard_overview import render_evolution_tab, render_portfolio_tab
 from src.portfolio.dashboard_reports import render_reports_tab
@@ -35,16 +36,27 @@ def main() -> None:
     render_hero()
     render_sidebar(settings)
 
-    tabs = st.tabs(["Vista general", "Evolucion", "Informes", "Actualizar datos", "Agentes"])
+    tabs = st.tabs(
+        [
+            "Vista general",
+            "Aportacion",
+            "Evolucion",
+            "Informes",
+            "Actualizar datos",
+            "Agentes",
+        ]
+    )
     with tabs[0]:
         render_portfolio_tab(settings)
     with tabs[1]:
-        render_evolution_tab(settings)
+        render_contribution_lab_tab(settings)
     with tabs[2]:
-        render_reports_tab(settings)
+        render_evolution_tab(settings)
     with tabs[3]:
-        render_update_tab(settings)
+        render_reports_tab(settings)
     with tabs[4]:
+        render_update_tab(settings)
+    with tabs[5]:
         render_agents_tab(settings)
 
 

--- a/src/portfolio/dashboard_contribution_lab.py
+++ b/src/portfolio/dashboard_contribution_lab.py
@@ -1,0 +1,193 @@
+"""Deterministic monthly contribution simulator for Streamlit."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+import streamlit as st
+
+from src.application import (
+    ReadPortfolioTargetsUseCase,
+    SimulateContributionRequest,
+    SimulateContributionUseCase,
+)
+from src.config import Settings
+from src.portfolio.dashboard_common import (
+    format_currency,
+    format_pct,
+    section_header,
+)
+
+
+def render_contribution_lab_tab(settings: Settings) -> None:
+    """Render controls and results without duplicating planning logic."""
+    section_header(
+        "Laboratorio de aportacion",
+        "Simula como repartir una aportacion entre posiciones actuales sin vender ni ejecutar ordenes.",
+    )
+    st.info(
+        "Es una simulacion determinista y offline sobre las posiciones actuales. "
+        "Nunca vende ni ejecuta ordenes."
+    )
+
+    targets_state = ReadPortfolioTargetsUseCase(settings=settings).execute()
+    targets = targets_state.portfolio_targets
+    targets_available = targets is not None and targets_state.validation_error is None
+    mapping_available = (
+        targets_available
+        and isinstance(targets.get("asset_bucket_mapping"), Mapping)
+        and bool(targets["asset_bucket_mapping"])
+    )
+    if targets_state.validation_error:
+        st.error(f"Los portfolio targets no son validos: {targets_state.validation_error}")
+    elif targets is None:
+        st.warning(
+            "No hay portfolio targets configurados. Guardalos primero desde la pestana Agentes."
+        )
+    elif not mapping_available:
+        st.warning(
+            "Falta asset_bucket_mapping en los portfolio targets. Asigna cada "
+            "posicion activa a un bucket antes de simular."
+        )
+
+    target_values = targets or {}
+    base_currency = str(target_values.get("base_currency") or settings.default_currency)
+    configured_contribution = target_values.get("monthly_contribution")
+    if configured_contribution is None:
+        configured_contribution = settings.monthly_contribution_eur
+
+    with st.form("contribution_simulation_form"):
+        left, right = st.columns(2)
+        with left:
+            contribution_amount = st.number_input(
+                f"Aportacion ({base_currency})",
+                min_value=0.0,
+                value=float(configured_contribution),
+                step=50.0,
+                help="Efectivo nuevo disponible para esta simulacion.",
+            )
+            allow_fractional_units = st.checkbox(
+                "Permitir unidades fraccionarias",
+                value=False,
+            )
+        with right:
+            minimum_order_value = st.number_input(
+                f"Orden minima ({base_currency})",
+                min_value=0.0,
+                value=25.0,
+                step=5.0,
+            )
+            max_orders = st.number_input(
+                "Maximo de ordenes",
+                min_value=1,
+                max_value=100,
+                value=4,
+                step=1,
+            )
+        submitted = st.form_submit_button(
+            "Simular aportacion",
+            type="primary",
+            disabled=not mapping_available,
+            width="stretch",
+        )
+
+    if not submitted:
+        return
+
+    result = SimulateContributionUseCase(settings=settings).execute(
+        SimulateContributionRequest(
+            contribution_amount=float(contribution_amount),
+            allow_fractional_units=bool(allow_fractional_units),
+            minimum_order_value=float(minimum_order_value),
+            max_orders=int(max_orders),
+            as_of_date=None,
+        )
+    )
+    _render_simulation_result(result.to_dict())
+
+
+def _render_simulation_result(payload: Mapping[str, Any]) -> None:
+    status = str(payload.get("status") or "failed")
+    message = str(payload.get("message") or "No se pudo completar la simulacion.")
+    if status == "succeeded":
+        st.success(message)
+    elif status == "partial":
+        st.warning(message)
+    else:
+        st.error(message)
+
+    _render_message_list("Avisos", payload.get("warnings"))
+    _render_message_list("Supuestos", payload.get("assumptions"))
+
+    simulation = payload.get("simulation")
+    if not isinstance(simulation, Mapping):
+        return
+
+    base_currency = str(simulation.get("base_currency") or "")
+    as_of_date = simulation.get("as_of_date")
+    if as_of_date:
+        st.caption(f"Estado de cartera usado: {as_of_date}")
+
+    metrics = st.columns(5)
+    metrics[0].metric(
+        "Presupuesto",
+        format_currency(simulation.get("budget"), base_currency),
+    )
+    metrics[1].metric(
+        "Compras propuestas",
+        format_currency(simulation.get("invested_amount"), base_currency),
+    )
+    metrics[2].metric(
+        "Efectivo restante",
+        format_currency(simulation.get("remaining_cash"), base_currency),
+    )
+    metrics[3].metric(
+        "Desviacion antes",
+        format_pct(simulation.get("deviation_before")),
+    )
+    metrics[4].metric(
+        "Desviacion despues",
+        format_pct(simulation.get("deviation_after")),
+    )
+    st.caption(
+        '"Antes" es la cartera actual antes de compras. "Despues" incorpora solo '
+        "las compras propuestas; el efectivo que no se invierte queda fuera de "
+        "esos pesos y se muestra por separado."
+    )
+
+    orders = simulation.get("orders")
+    st.markdown("#### Compras propuestas")
+    if isinstance(orders, list) and orders:
+        st.dataframe(orders, width="stretch", hide_index=True)
+    else:
+        st.info("No hay ninguna compra que mejore la desviacion respetando las restricciones.")
+
+    bucket_allocations = simulation.get("bucket_allocations")
+    st.markdown("#### Pesos y desviacion por bucket")
+    if isinstance(bucket_allocations, list) and bucket_allocations:
+        st.dataframe(bucket_allocations, width="stretch", hide_index=True)
+    else:
+        st.info("No hay detalle de buckets disponible.")
+
+    constraints = simulation.get("constraint_events")
+    if constraints is None:
+        constraints = simulation.get("constraints")
+    st.markdown("#### Restricciones activadas")
+    if isinstance(constraints, list) and constraints:
+        if all(isinstance(item, Mapping) for item in constraints):
+            st.dataframe(constraints, width="stretch", hide_index=True)
+        else:
+            _render_message_list(None, constraints)
+    else:
+        st.caption("Ninguna restriccion adicional activada.")
+
+
+def _render_message_list(title: str | None, values: Any) -> None:
+    if not isinstance(values, (list, tuple)) or not values:
+        return
+    if title:
+        st.markdown(f"**{title}**")
+    st.markdown("\n".join(f"- {value}" for value in values))
+
+
+__all__ = ["render_contribution_lab_tab"]

--- a/src/portfolio/targets.py
+++ b/src/portfolio/targets.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import json
 import math
 from pathlib import Path
@@ -22,6 +22,7 @@ class PortfolioTargets:
     max_single_asset_weight: float | None = None
     max_sector_weight: float | None = None
     rebalance_mode: str | None = None
+    asset_bucket_mapping: Mapping[str, str] = field(default_factory=dict)
 
     def target_weights(self) -> dict[str, float]:
         """Return target allocation weights normalized to decimal units."""
@@ -37,6 +38,7 @@ class PortfolioTargets:
             "max_single_asset_weight": self.max_single_asset_weight,
             "max_sector_weight": self.max_sector_weight,
             "rebalance_mode": self.rebalance_mode,
+            "asset_bucket_mapping": dict(self.asset_bucket_mapping),
         }
 
     def to_agent_payload(self) -> dict[str, Any]:
@@ -114,6 +116,10 @@ def portfolio_targets_from_mapping(
         max_single_asset_weight=_optional_weight(data.get("max_single_asset_weight"), field_name="max_single_asset_weight"),
         max_sector_weight=_optional_weight(data.get("max_sector_weight"), field_name="max_sector_weight"),
         rebalance_mode=_optional_str(data.get("rebalance_mode")),
+        asset_bucket_mapping=_normalize_asset_bucket_mapping(
+            data.get("asset_bucket_mapping"),
+            valid_buckets=set(normalized_allocation),
+        ),
     )
 
 
@@ -157,9 +163,21 @@ def _parse_simple_yaml(text: str) -> dict[str, Any]:
 
 
 def _split_yaml_key_value(line: str) -> tuple[str, str]:
-    if ":" not in line:
+    separator_index = next(
+        (
+            index
+            for index, character in enumerate(line)
+            if character == ":" and (index + 1 == len(line) or line[index + 1].isspace())
+        ),
+        -1,
+    )
+    # Preserve the permissive legacy ``key:value`` syntax when no YAML-style
+    # separator exists, while allowing canonical asset IDs to contain colons.
+    if separator_index < 0:
+        separator_index = line.find(":")
+    if separator_index < 0:
         raise ValueError(f"Invalid YAML line: {line}")
-    key, value = line.split(":", 1)
+    key, value = line[:separator_index], line[separator_index + 1 :]
     key = key.strip()
     if not key:
         raise ValueError(f"Invalid empty YAML key: {line}")
@@ -209,6 +227,38 @@ def _normalize_weights(raw_weights: Mapping[str, Any], *, field_name: str) -> di
     else:
         raise ValueError(f"{field_name} weights must sum to 1.0 or 100.0.")
     return {name: value / divisor for name, value in weights.items()}
+
+
+def _normalize_asset_bucket_mapping(
+    raw_mapping: Any,
+    *,
+    valid_buckets: set[str],
+) -> dict[str, str]:
+    if raw_mapping is None:
+        return {}
+    if not isinstance(raw_mapping, Mapping):
+        raise ValueError("asset_bucket_mapping must be a mapping.")
+
+    normalized: dict[str, str] = {}
+    for raw_identifier, raw_bucket in raw_mapping.items():
+        if not isinstance(raw_identifier, str) or not isinstance(raw_bucket, str):
+            raise ValueError("asset_bucket_mapping keys and values must be strings.")
+        identifier = raw_identifier.strip()
+        bucket = raw_bucket.strip()
+        if not identifier:
+            raise ValueError("asset_bucket_mapping contains an empty identifier.")
+        if not bucket:
+            raise ValueError(f"asset_bucket_mapping[{identifier!r}] contains an empty bucket.")
+        if identifier in normalized:
+            raise ValueError(
+                f"asset_bucket_mapping contains duplicate identifier {identifier!r} after normalization."
+            )
+        if bucket not in valid_buckets:
+            raise ValueError(
+                f"asset_bucket_mapping[{identifier!r}] references unknown target bucket {bucket!r}."
+            )
+        normalized[identifier] = bucket
+    return normalized
 
 
 def _optional_weight(value: Any, *, field_name: str) -> float | None:

--- a/tests/test_application_layer.py
+++ b/tests/test_application_layer.py
@@ -244,6 +244,7 @@ def test_read_portfolio_targets_returns_complete_strict_json_model() -> None:
             "max_single_asset_weight": 0.25,
             "max_sector_weight": 0.40,
             "rebalance_mode": "contributions_only",
+            "asset_bucket_mapping": {},
         }
         assert targets.content_hash.startswith("sha256:")
         json.dumps(targets.to_dict(), allow_nan=False)

--- a/tests/test_contribution_application.py
+++ b/tests/test_contribution_application.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+from types import SimpleNamespace
+from typing import Any
+
+from src.application import (
+    SimulateContributionRequest,
+    SimulateContributionUseCase,
+)
+from src.config import load_settings
+
+
+class _TargetsUseCase:
+    def __init__(self, portfolio_targets: dict[str, Any] | None) -> None:
+        self.portfolio_targets = portfolio_targets
+        self.calls = 0
+
+    def execute(self) -> SimpleNamespace:
+        self.calls += 1
+        return SimpleNamespace(
+            portfolio_targets=deepcopy(self.portfolio_targets),
+            validation_error=None,
+            content_hash="sha256:test-targets",
+        )
+
+
+class _StateUseCase:
+    def __init__(
+        self,
+        positions: list[dict[str, Any]],
+        *,
+        warnings: list[str] | None = None,
+    ) -> None:
+        self.positions = positions
+        self.warnings = warnings or []
+        self.requests: list[Any] = []
+
+    def execute(self, request: Any) -> SimpleNamespace:
+        self.requests.append(request)
+        return SimpleNamespace(
+            as_of_date="2026-07-30",
+            base_currency="EUR",
+            positions=deepcopy(self.positions),
+            data_quality={"warnings": list(self.warnings)},
+        )
+
+
+def _targets(
+    mapping: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "base_currency": "EUR",
+        "target_allocation": {
+            "core": 0.60,
+            "satellite": 0.30,
+            "cash": 0.10,
+        },
+        "monthly_contribution": 200.0,
+        "max_single_asset_weight": 0.80,
+        "rebalance_mode": "contributions_only",
+        "asset_bucket_mapping": mapping
+        or {
+            "asset-core": "core",
+            "asset-satellite": "satellite",
+            "asset-cash": "cash",
+        },
+    }
+
+
+def _positions() -> list[dict[str, Any]]:
+    return [
+        {
+            "asset_id": "asset-core",
+            "isin": "IE00CORE00001",
+            "asset_type": "etf",
+            "quantity": 8.0,
+            "market_value_base": 800.0,
+        },
+        {
+            "asset_id": "asset-satellite",
+            "isin": "IE00SAT000001",
+            "asset_type": "etf",
+            "quantity": 1.0,
+            "market_value_base": 100.0,
+        },
+        {
+            "asset_id": "asset-cash",
+            "isin": None,
+            "asset_type": "cash",
+            "quantity": 100.0,
+            "market_value_base": 100.0,
+        },
+    ]
+
+
+def _use_case(
+    tmp_path: Any,
+    *,
+    targets: dict[str, Any] | None = None,
+    positions: list[dict[str, Any]] | None = None,
+    warnings: list[str] | None = None,
+) -> tuple[SimulateContributionUseCase, _TargetsUseCase, _StateUseCase]:
+    settings = load_settings(
+        repo_root=tmp_path,
+        env={},
+        env_file=tmp_path / ".env.missing",
+    )
+    targets_use_case = _TargetsUseCase(
+        targets if targets is not None else _targets()
+    )
+    state_use_case = _StateUseCase(
+        positions if positions is not None else _positions(),
+        warnings=warnings,
+    )
+    use_case = SimulateContributionUseCase(
+        settings=settings,
+        targets_use_case=targets_use_case,  # type: ignore[arg-type]
+        state_use_case=state_use_case,  # type: ignore[arg-type]
+    )
+    return use_case, targets_use_case, state_use_case
+
+
+def test_simulation_composes_server_side_state_and_targets_as_strict_json(
+    tmp_path: Any,
+) -> None:
+    positions = _positions()
+    positions_before = deepcopy(positions)
+    use_case, _, state_use_case = _use_case(tmp_path, positions=positions)
+
+    result = use_case.execute()
+    payload = result.to_dict()
+
+    assert payload["status"] == "succeeded"
+    assert payload["simulation"]["invested_amount"] == 200.0
+    assert payload["simulation"]["remaining_cash"] == 0.0
+    assert payload["simulation"]["orders"] == [
+        {
+            "asset_id": "asset-satellite",
+            "isin": "IE00SAT000001",
+            "bucket": "satellite",
+            "quantity": 2.0,
+            "unit_price_base": 100.0,
+            "amount_base": 200.0,
+            "weight_before": 0.10,
+            "weight_after": 0.25,
+        }
+    ]
+    assert payload["simulation"]["deviation_after"] <= payload["simulation"][
+        "deviation_before"
+    ]
+    assert payload["simulation"]["targets_content_hash"] == "sha256:test-targets"
+    assert payload["assumptions"].count(
+        "remaining_cash_excluded_from_after_weights"
+    ) == 1
+    assert state_use_case.requests[0].persist is False
+    assert state_use_case.requests[0].include_positions is True
+    assert state_use_case.requests[0].include_history is False
+    assert positions == positions_before
+    json.dumps(payload, allow_nan=False)
+
+
+def test_simulation_uses_case_insensitive_isin_mapping(tmp_path: Any) -> None:
+    mapping = {
+        "ie00core00001": "core",
+        "ie00sat000001": "satellite",
+        "asset-cash": "cash",
+    }
+    use_case, _, _ = _use_case(tmp_path, targets=_targets(mapping))
+
+    result = use_case.execute(
+        SimulateContributionRequest(
+            contribution_amount=200,
+            allow_fractional_units=True,
+        )
+    )
+
+    assert result.result.status == "succeeded"
+    assert result.simulation is not None
+    assert result.simulation["orders"][0]["asset_id"] == "asset-satellite"
+
+
+def test_simulation_skips_orders_when_an_active_position_is_unmapped(
+    tmp_path: Any,
+) -> None:
+    mapping = {
+        "asset-core": "core",
+        "asset-cash": "cash",
+    }
+    use_case, _, _ = _use_case(tmp_path, targets=_targets(mapping))
+
+    result = use_case.execute()
+
+    assert result.result.status == "partial"
+    assert result.simulation is not None
+    assert result.simulation["orders"] == []
+    assert result.simulation["remaining_cash"] == 200.0
+    assert "missing_asset_bucket_mapping:asset-satellite" in result.result.warnings
+
+
+def test_simulation_rejects_conflicting_asset_and_isin_mappings(
+    tmp_path: Any,
+) -> None:
+    mapping = {
+        "asset-core": "core",
+        "asset-satellite": "satellite",
+        "IE00SAT000001": "core",
+        "asset-cash": "cash",
+    }
+    use_case, _, _ = _use_case(tmp_path, targets=_targets(mapping))
+
+    result = use_case.execute()
+
+    assert result.result.status == "failed"
+    assert result.simulation is None
+    assert "Conflicting asset_bucket_mapping" in result.result.message
+
+
+def test_simulation_propagates_state_and_stale_mapping_warnings(
+    tmp_path: Any,
+) -> None:
+    targets = _targets()
+    targets["asset_bucket_mapping"]["unused-id"] = "core"
+    use_case, _, _ = _use_case(
+        tmp_path,
+        targets=targets,
+        warnings=["state_projection_warning"],
+    )
+
+    result = use_case.execute()
+
+    assert result.result.status == "partial"
+    assert "state_projection_warning" in result.result.warnings
+    assert "unused_mapping_entry:unused-id" in result.result.warnings
+    assert result.simulation is not None
+    assert result.simulation["orders"]
+
+
+def test_simulation_rejects_invalid_request_before_reading_local_state(
+    tmp_path: Any,
+) -> None:
+    use_case, targets_use_case, state_use_case = _use_case(tmp_path)
+
+    result = use_case.execute(
+        SimulateContributionRequest(contribution_amount=float("nan"))
+    )
+
+    assert result.result.status == "failed"
+    assert result.simulation is None
+    assert targets_use_case.calls == 0
+    assert state_use_case.requests == []
+    json.dumps(result.to_dict(), allow_nan=False)
+
+
+def test_empty_portfolio_returns_partial_without_orders(tmp_path: Any) -> None:
+    use_case, _, _ = _use_case(tmp_path, positions=[])
+
+    result = use_case.execute()
+
+    assert result.result.status == "partial"
+    assert "no_current_positions" in result.result.warnings
+    assert result.simulation is not None
+    assert result.simulation["orders"] == []
+    assert result.simulation["remaining_cash"] == 200.0

--- a/tests/test_contribution_planner.py
+++ b/tests/test_contribution_planner.py
@@ -1,0 +1,423 @@
+from __future__ import annotations
+
+from dataclasses import replace
+import json
+import math
+
+import pytest
+
+from src.portfolio.contribution_planner import (
+    ContributionConstraints,
+    ContributionPosition,
+    plan_contribution,
+)
+
+
+def _position(
+    asset_id: str,
+    bucket: str,
+    value: float,
+    *,
+    price: float | None = 100.0,
+    asset_type: str = "etf",
+) -> ContributionPosition:
+    quantity = value / price if price else 0.0
+    return ContributionPosition(
+        asset_id=asset_id,
+        isin=f"ISIN-{asset_id}",
+        bucket=bucket,
+        quantity=quantity,
+        market_value_base=value,
+        unit_price_base=price,
+        asset_type=asset_type,
+    )
+
+
+def _portfolio() -> tuple[ContributionPosition, ...]:
+    return (
+        _position("core", "core", 800.0),
+        _position("satellite", "satellite", 100.0),
+        _position("cash", "cash", 100.0, price=None, asset_type="cash"),
+    )
+
+
+def _targets() -> dict[str, float]:
+    return {"core": 0.60, "satellite": 0.30, "cash": 0.10}
+
+
+def test_whole_unit_plan_improves_deviation_and_preserves_residual_cash() -> None:
+    positions = _portfolio()
+
+    plan = plan_contribution(
+        positions,
+        _targets(),
+        ContributionConstraints(contribution_amount=250.0, max_orders=2),
+    )
+
+    assert plan.invested_amount == 200.0
+    assert plan.remaining_cash == 50.0
+    assert plan.deviation_after < plan.deviation_before
+    assert len(plan.orders) == 1
+    assert plan.orders[0].asset_id == "satellite"
+    assert plan.orders[0].quantity == 2.0
+    assert plan.orders[0].amount_base == 200.0
+    assert all(order.quantity > 0 for order in plan.orders)
+    assert sum(order.amount_base for order in plan.orders) <= plan.budget
+    assert positions == _portfolio()
+    json.dumps(plan.to_dict(), allow_nan=False)
+
+
+def test_fractional_plan_can_use_the_complete_budget() -> None:
+    plan = plan_contribution(
+        _portfolio(),
+        _targets(),
+        ContributionConstraints(
+            contribution_amount=175.0,
+            allow_fractional_units=True,
+        ),
+    )
+
+    assert plan.invested_amount == 175.0
+    assert plan.remaining_cash == 0.0
+    assert plan.orders[0].quantity == 1.75
+    assert plan.orders[0].amount_base == 175.0
+
+
+def test_minimum_order_and_whole_units_can_leave_all_budget_unspent() -> None:
+    plan = plan_contribution(
+        _portfolio(),
+        _targets(),
+        ContributionConstraints(
+            contribution_amount=80.0,
+            minimum_order_value=50.0,
+        ),
+    )
+
+    assert plan.orders == ()
+    assert plan.invested_amount == 0.0
+    assert plan.remaining_cash == 80.0
+    assert plan.deviation_after == plan.deviation_before
+    assert "whole_units_unaffordable:satellite" in plan.constraint_events
+
+
+def test_max_orders_uses_stable_bucket_and_identifier_tiebreaks() -> None:
+    positions = (
+        _position("core", "core", 800.0, price=50.0),
+        _position("asset-beta", "beta", 100.0, price=50.0),
+        _position("asset-alpha", "alpha", 100.0, price=50.0),
+    )
+
+    first = plan_contribution(
+        positions,
+        {"core": 0.60, "alpha": 0.20, "beta": 0.20},
+        ContributionConstraints(contribution_amount=200.0, max_orders=1),
+    )
+    second = plan_contribution(
+        tuple(reversed(positions)),
+        {"beta": 0.20, "alpha": 0.20, "core": 0.60},
+        ContributionConstraints(contribution_amount=200.0, max_orders=1),
+    )
+
+    assert [order.to_dict() for order in first.orders] == [
+        order.to_dict() for order in second.orders
+    ]
+    assert first.orders[0].asset_id == "asset-alpha"
+    assert "max_orders_reached" in first.constraint_events
+
+
+def test_single_asset_cap_is_never_exceeded() -> None:
+    plan = plan_contribution(
+        _portfolio(),
+        _targets(),
+        ContributionConstraints(
+            contribution_amount=200.0,
+            allow_fractional_units=True,
+            max_single_asset_weight=0.15,
+        ),
+    )
+
+    satellite_order = plan.orders[0]
+    final_total = 1_000.0 + plan.invested_amount
+    assert (100.0 + satellite_order.amount_base) / final_total <= 0.15 + 1e-9
+    assert plan.remaining_cash > 0
+    assert "max_single_asset_weight:satellite" in plan.constraint_events
+
+
+def test_multiple_assets_in_one_bucket_are_planned_without_mutation() -> None:
+    positions = (
+        _position("core", "core", 800.0),
+        _position("satellite-a", "satellite", 50.0, price=25.0),
+        _position("satellite-b", "satellite", 50.0, price=25.0),
+        _position("cash", "cash", 100.0, price=None, asset_type="cash"),
+    )
+    original = tuple(positions)
+
+    plan = plan_contribution(
+        positions,
+        _targets(),
+        ContributionConstraints(
+            contribution_amount=200.0,
+            allow_fractional_units=True,
+            max_orders=2,
+            max_single_asset_weight=0.15,
+        ),
+    )
+
+    assert plan.invested_amount == 200.0
+    assert {order.asset_id for order in plan.orders} == {
+        "satellite-a",
+        "satellite-b",
+    }
+    assert plan.deviation_after < plan.deviation_before
+    assert positions == original
+
+
+def test_no_purchase_is_forced_when_current_weights_match_targets() -> None:
+    positions = (
+        _position("core", "core", 600.0),
+        _position("satellite", "satellite", 300.0),
+        _position("cash", "cash", 100.0, price=None, asset_type="cash"),
+    )
+
+    plan = plan_contribution(
+        positions,
+        _targets(),
+        ContributionConstraints(contribution_amount=200.0),
+    )
+
+    assert plan.orders == ()
+    assert plan.deviation_before == 0.0
+    assert plan.deviation_after == 0.0
+    assert plan.remaining_cash == 200.0
+    assert "no_improving_purchase" in plan.warnings
+
+
+def test_unusable_unit_price_is_reported_and_never_bought() -> None:
+    positions = (
+        _position("core", "core", 800.0),
+        replace(_position("satellite", "satellite", 100.0), unit_price_base=None),
+        _position("cash", "cash", 100.0, price=None, asset_type="cash"),
+    )
+
+    plan = plan_contribution(
+        positions,
+        _targets(),
+        ContributionConstraints(contribution_amount=200.0),
+    )
+
+    assert plan.orders == ()
+    assert "asset_not_buyable:satellite" in plan.constraint_events
+    assert plan.deviation_after == plan.deviation_before
+
+
+@pytest.mark.parametrize(
+    ("targets", "constraints", "error"),
+    [
+        (
+            {"core": 1.0},
+            ContributionConstraints(contribution_amount=float("nan")),
+            "contribution_amount",
+        ),
+        (
+            {"core": 0.9},
+            ContributionConstraints(contribution_amount=100.0),
+            "sum to 1.0",
+        ),
+        (
+            {"core": 1.0},
+            ContributionConstraints(contribution_amount=100.0, max_orders=0),
+            "max_orders",
+        ),
+        (
+            {"core": 1.0},
+            ContributionConstraints(
+                contribution_amount=100.0,
+                max_single_asset_weight=1.1,
+            ),
+            "max_single_asset_weight",
+        ),
+    ],
+)
+def test_invalid_inputs_fail_before_planning(
+    targets: dict[str, float],
+    constraints: ContributionConstraints,
+    error: str,
+) -> None:
+    with pytest.raises(ValueError, match=error):
+        plan_contribution(
+            (_position("core", "core", 100.0),),
+            targets,
+            constraints,
+        )
+
+
+def test_aggregate_values_must_remain_json_finite() -> None:
+    positions = (
+        _position("core-a", "core", 1e308),
+        _position("core-b", "core", 1e308),
+    )
+
+    with pytest.raises(ValueError, match="must remain finite"):
+        plan_contribution(
+            positions,
+            {"core": 1.0},
+            ContributionConstraints(contribution_amount=100.0),
+        )
+
+
+def test_whole_order_never_uses_epsilon_to_exceed_budget_or_cap() -> None:
+    budget = 99.9999999995
+    cap = (100.0 + budget) / (1_000.0 + budget)
+
+    plan = plan_contribution(
+        _portfolio(),
+        _targets(),
+        ContributionConstraints(
+            contribution_amount=budget,
+            max_single_asset_weight=cap,
+        ),
+    )
+
+    assert sum(order.amount_base for order in plan.orders) <= budget
+    assert plan.invested_amount <= budget
+    for order in plan.orders:
+        final_weight = (
+            100.0 + order.amount_base
+        ) / (1_000.0 + plan.invested_amount)
+        assert final_weight <= cap
+
+
+def test_fractional_order_must_meet_minimum_exactly() -> None:
+    budget = 99.9999999995
+
+    plan = plan_contribution(
+        _portfolio(),
+        _targets(),
+        ContributionConstraints(
+            contribution_amount=budget,
+            allow_fractional_units=True,
+            minimum_order_value=100.0,
+        ),
+    )
+
+    assert plan.orders == ()
+    assert plan.invested_amount == 0.0
+    assert "minimum_order_not_met:satellite" in plan.constraint_events
+
+
+def test_extreme_finite_inputs_cannot_emit_infinite_quantities() -> None:
+    positions = (
+        _position("large", "core", 1e308, price=1e307),
+        _position("tiny-price", "satellite", 0.0, price=1e-9),
+    )
+
+    plan = plan_contribution(
+        positions,
+        {"core": 0.10, "satellite": 0.90},
+        ContributionConstraints(
+            contribution_amount=1e307,
+            allow_fractional_units=True,
+        ),
+    )
+
+    assert plan.orders == ()
+    assert "non_finite_quantity:tiny-price" in plan.constraint_events
+    json.dumps(plan.to_dict(), allow_nan=False)
+
+
+def test_constraint_event_order_is_independent_of_position_order() -> None:
+    positions = (
+        _position("b", "satellite", 100.0, price=None),
+        _position("a", "core", 900.0, price=None),
+    )
+    constraints = ContributionConstraints(contribution_amount=100.0)
+    targets = {"core": 0.50, "satellite": 0.50}
+
+    first = plan_contribution(positions, targets, constraints)
+    second = plan_contribution(tuple(reversed(positions)), targets, constraints)
+
+    assert first.to_dict() == second.to_dict()
+
+
+def test_fractional_accumulation_never_rounds_above_budget() -> None:
+    positions = (
+        ContributionPosition("a", "a", 57.19, 571.9, 10.0),
+        ContributionPosition("b", "b", 61.58, 615.8, 10.0),
+        ContributionPosition("c", "c", 89.66, 896.6, 10.0),
+    )
+    budget = 4_529.39
+
+    plan = plan_contribution(
+        positions,
+        {"a": 0.45, "b": 0.05, "c": 0.50},
+        ContributionConstraints(
+            contribution_amount=budget,
+            allow_fractional_units=True,
+            max_orders=3,
+        ),
+    )
+
+    assert plan.invested_amount <= budget
+    assert sum(order.amount_base for order in plan.orders) <= budget
+
+
+def test_canonical_cash_id_is_never_treated_as_buyable() -> None:
+    positions = (
+        _position("core", "core", 900.0),
+        _position(
+            "degiro:cash:eur",
+            "cash",
+            100.0,
+            price=1.0,
+            asset_type="unknown",
+        ),
+    )
+
+    plan = plan_contribution(
+        positions,
+        {"core": 0.50, "cash": 0.50},
+        ContributionConstraints(contribution_amount=200.0),
+    )
+
+    assert plan.orders == ()
+
+
+def test_extreme_minimum_order_ratio_does_not_overflow() -> None:
+    positions = (
+        _position("core", "core", 1e299, price=1e299),
+        _position("satellite", "satellite", 1.0, price=1e-9),
+    )
+
+    plan = plan_contribution(
+        positions,
+        {"core": 0.10, "satellite": 0.90},
+        ContributionConstraints(
+            contribution_amount=1e299,
+            minimum_order_value=1e308,
+        ),
+    )
+
+    assert plan.orders == ()
+    json.dumps(plan.to_dict(), allow_nan=False)
+
+
+def test_fractional_quantity_accumulation_stays_json_finite() -> None:
+    scale = 1e296
+    positions = (
+        ContributionPosition("a", "a", 1.0, 571.9 * scale, 1e-9),
+        ContributionPosition("b", "b", 1.0, 615.8 * scale, 1e-9),
+        ContributionPosition("c", "c", 1.0, 896.6 * scale, 1e-9),
+    )
+
+    plan = plan_contribution(
+        positions,
+        {"a": 0.45, "b": 0.05, "c": 0.50},
+        ContributionConstraints(
+            contribution_amount=4_529.39 * scale,
+            allow_fractional_units=True,
+            max_orders=3,
+        ),
+    )
+
+    assert all(math.isfinite(order.quantity) for order in plan.orders)
+    json.dumps(plan.to_dict(), allow_nan=False)

--- a/tests/test_interface_boundaries.py
+++ b/tests/test_interface_boundaries.py
@@ -40,6 +40,11 @@ PORTFOLIO_TARGET_APPLICATION_CONTRACT = {
     "UpdatePortfolioTargetsRequest",
     "UpdatePortfolioTargetsUseCase",
 }
+CONTRIBUTION_LAB_APPLICATION_CONTRACT = {
+    "ReadPortfolioTargetsUseCase",
+    "SimulateContributionRequest",
+    "SimulateContributionUseCase",
+}
 
 
 @pytest.mark.parametrize("script_name", USER_FACING_SCRIPTS)
@@ -90,6 +95,18 @@ def test_dashboard_portfolio_targets_use_application_contract() -> None:
 
     assert violations == []
     assert PORTFOLIO_TARGET_APPLICATION_CONTRACT <= application_symbols
+
+
+def test_contribution_lab_uses_application_contract() -> None:
+    repo_root = default_repo_root()
+    path = repo_root / "src" / "portfolio" / "dashboard_contribution_lab.py"
+    application_symbols = {
+        symbol
+        for module, symbol, _line_number in _imported_symbols(path)
+        if module.startswith("src.application")
+    }
+
+    assert CONTRIBUTION_LAB_APPLICATION_CONTRACT <= application_symbols
 
 
 @pytest.mark.parametrize(

--- a/tests/test_portfolio_targets.py
+++ b/tests/test_portfolio_targets.py
@@ -57,6 +57,7 @@ def test_load_portfolio_targets_from_simple_yaml(workspace_tmp_path: Path) -> No
     assert targets.target_weights() == {"ETFs": 0.70, "stocks": 0.20, "cash": 0.10}
     assert targets.max_single_asset_weight == 0.15
     assert targets.max_sector_weight == 0.30
+    assert targets.asset_bucket_mapping == {}
     assert targets.to_agent_payload()["rebalance_mode"] == "contributions_only"
 
 
@@ -93,6 +94,7 @@ def test_portfolio_targets_accepts_legacy_target_weights_alias() -> None:
         "max_single_asset_weight": None,
         "max_sector_weight": None,
         "rebalance_mode": None,
+        "asset_bucket_mapping": {},
     }
 
 
@@ -104,6 +106,85 @@ def test_portfolio_targets_rejects_conflicting_allocation_aliases() -> None:
                 "target_weights": {"core": 0.70, "satellite": 0.30},
             }
         )
+
+
+def test_portfolio_targets_normalizes_valid_asset_bucket_mapping() -> None:
+    targets = portfolio_targets_from_mapping(
+        {
+            "target_allocation": {"core": 0.80, "cash": 0.20},
+            "asset_bucket_mapping": {
+                " degiro:isin:IE00TEST0001 ": " core ",
+                "degiro:cash:eur": "cash",
+            },
+        }
+    )
+
+    assert targets.asset_bucket_mapping == {
+        "degiro:isin:IE00TEST0001": "core",
+        "degiro:cash:eur": "cash",
+    }
+    assert targets.to_storage_mapping()["asset_bucket_mapping"] == targets.asset_bucket_mapping
+    assert "asset_bucket_mapping" not in targets.to_agent_payload()
+
+
+@pytest.mark.parametrize(
+    ("asset_bucket_mapping", "error"),
+    [
+        ([], "must be a mapping"),
+        ({1: "core"}, "keys and values must be strings"),
+        ({"asset": 1}, "keys and values must be strings"),
+        ({" ": "core"}, "empty identifier"),
+        ({"asset": " "}, "empty bucket"),
+        ({"asset": "satellite"}, "unknown target bucket"),
+        (
+            {"asset": "core", " asset ": "core"},
+            "duplicate identifier 'asset' after normalization",
+        ),
+    ],
+)
+def test_portfolio_targets_rejects_invalid_asset_bucket_mapping(
+    asset_bucket_mapping: object,
+    error: str,
+) -> None:
+    with pytest.raises(ValueError, match=error):
+        portfolio_targets_from_mapping(
+            {
+                "target_allocation": {"core": 1.0},
+                "asset_bucket_mapping": asset_bucket_mapping,
+            }
+        )
+
+
+def test_simple_yaml_supports_colons_in_asset_bucket_keys(workspace_tmp_path: Path) -> None:
+    targets_path = workspace_tmp_path / "portfolio_targets.yaml"
+    targets_path.write_text(
+        "\n".join(
+            [
+                "target_allocation:",
+                "  core: 80",
+                "  cash: 20",
+                "asset_bucket_mapping:",
+                "  degiro:isin:IE00TEST0001: core",
+                "  degiro:cash:eur: cash",
+                "risk_profile: medium:term",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    settings = load_settings(
+        repo_root=workspace_tmp_path,
+        env={"PORTFOLIO_TARGETS_PATH": str(targets_path)},
+        env_file=workspace_tmp_path / ".env.missing",
+    )
+
+    targets = load_portfolio_targets(settings=settings, required=True)
+
+    assert targets is not None
+    assert targets.asset_bucket_mapping == {
+        "degiro:isin:IE00TEST0001": "core",
+        "degiro:cash:eur": "cash",
+    }
+    assert targets.risk_profile == "medium:term"
 
 
 def test_portfolio_targets_applies_one_scale_to_the_complete_allocation() -> None:

--- a/tests/test_streamlit_dashboard_smoke.py
+++ b/tests/test_streamlit_dashboard_smoke.py
@@ -37,10 +37,12 @@ def test_dashboard_renders_with_an_empty_isolated_workspace(tmp_path, monkeypatc
     assert not app.exception
     assert [tab.label for tab in app.tabs] == [
         "Vista general",
+        "Aportacion",
         "Evolucion",
         "Informes",
         "Actualizar datos",
         "Agentes",
     ]
+    assert any(button.label == "Simular aportacion" for button in app.button)
     assert any("No se pudieron calcular metricas" in error.value for error in app.error)
     clear_settings_cache()


### PR DESCRIPTION
## Resumen
- añade planificación determinista contributions_only con límites y caja residual
- incorpora mapping validado, caso de uso JSON-ready y pestaña Streamlit
- actualiza demo, contratos, documentación y pruebas

## Validación
- 258 tests
- Ruff y mypy
- cobertura 75%
- demo sintética y detect-secrets

Closes #42